### PR TITLE
add TcpStream::into_accepted to migrate live connections between executors

### DIFF
--- a/glommio/src/error.rs
+++ b/glommio/src/error.rs
@@ -357,6 +357,15 @@ impl<T> GlommioError<T> {
             kind: QueueErrorKind::NotFound,
         })
     }
+
+    pub fn into_inner(self) -> Option<T> {
+        match self {
+            GlommioError::Closed(ResourceType::Channel(t)) => Some(t),
+            GlommioError::WouldBlock(ResourceType::Channel(t)) => Some(t),
+            GlommioError::CanNotBeClosed(ResourceType::Channel(t), _) => Some(t),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for QueueErrorKind {

--- a/glommio/src/net/stream.rs
+++ b/glommio/src/net/stream.rs
@@ -13,7 +13,7 @@ use std::{
     cell::Cell,
     io,
     net::Shutdown,
-    os::unix::io::{AsRawFd, FromRawFd, RawFd},
+    os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
     rc::{Rc, Weak},
     task::{Context, Poll, Waker},
     time::{Duration, Instant},
@@ -508,5 +508,32 @@ impl<S: AsRawFd, B: Buffered> GlommioStream<S, B> {
 
     pub(crate) fn consume(&mut self, amt: usize) {
         self.rx_buf.consume(amt);
+    }
+}
+
+impl<S: AsRawFd + IntoRawFd> NonBufferedStream<S> {
+    /// Extracts the raw file descriptor, cleaning up glommio state
+    /// but keeping the fd open.
+    fn into_raw_fd(mut self) -> RawFd {
+        // Clean up reactor sources
+        self.source_tx.take();
+        self.source_rx.take();
+
+        // Cancel any pending timers
+        if let Some(reactor) = self.reactor.upgrade() {
+            self.write_timeout.cancel_timer(&reactor);
+            self.read_timeout.cancel_timer(&reactor);
+        }
+
+        // Extract fd from inner stream (this prevents it from closing)
+        self.stream.into_raw_fd()
+    }
+}
+
+impl<S: AsRawFd + IntoRawFd> GlommioStream<S, NonBuffered> {
+    /// Extracts the raw file descriptor, cleaning up glommio state
+    /// but keeping the fd open.
+    pub(crate) fn into_raw_fd(self) -> RawFd {
+        self.stream.into_raw_fd()
     }
 }

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -436,6 +436,25 @@ impl FromRawFd for TcpStream {
     }
 }
 
+impl IntoRawFd for TcpStream<NonBuffered> {
+    fn into_raw_fd(self) -> RawFd {
+        self.stream.into_raw_fd()
+    }
+}
+
+impl TcpStream<NonBuffered> {
+    /// Converts this TcpStream back into an AcceptedTcpStream that can be
+    /// transferred to another executor.
+    ///
+    /// This properly cleans up glommio internal state (reactor sources,
+    /// timers) while keeping the underlying file descriptor open.
+    pub fn into_accepted(self) -> AcceptedTcpStream {
+        AcceptedTcpStream {
+            fd: self.into_raw_fd(),
+        }
+    }
+}
+
 fn make_tcp_socket(addr: &SocketAddr) -> io::Result<Socket> {
     let domain = if addr.is_ipv6() {
         Domain::IPV6
@@ -1330,5 +1349,124 @@ mod tests {
             let s = TcpStream::connect(addr).await.unwrap();
             assert_eq!(s.local_addr().unwrap(), peer_addr.await);
         });
+    }
+
+    #[test]
+    fn tcp_stream_into_raw_fd() {
+        test_executor!(async move {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+
+            let stream = TcpStream::connect(addr).await.unwrap();
+            let original_fd = stream.as_raw_fd();
+
+            let raw_fd = stream.into_raw_fd();
+            assert_eq!(original_fd, raw_fd);
+
+            let restored_stream = unsafe { TcpStream::from_raw_fd(raw_fd) };
+            assert_eq!(restored_stream.as_raw_fd(), raw_fd);
+
+            std::mem::drop(restored_stream);
+        });
+    }
+
+    #[test]
+    fn tcp_stream_into_raw_fd_with_timeouts() {
+        test_executor!(async move {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+
+            let stream = TcpStream::connect(addr).await.unwrap();
+
+            // Set timeouts to verify they get cleaned up
+            stream
+                .set_read_timeout(Some(Duration::from_secs(30)))
+                .unwrap();
+            stream
+                .set_write_timeout(Some(Duration::from_secs(30)))
+                .unwrap();
+
+            assert_eq!(stream.read_timeout(), Some(Duration::from_secs(30)));
+            assert_eq!(stream.write_timeout(), Some(Duration::from_secs(30)));
+
+            let original_fd = stream.as_raw_fd();
+
+            let raw_fd = stream.into_raw_fd();
+            assert_eq!(original_fd, raw_fd);
+
+            // Create a new stream and verify timeouts are reset
+            let restored_stream = unsafe { TcpStream::from_raw_fd(raw_fd) };
+            assert_eq!(restored_stream.read_timeout(), None);
+            assert_eq!(restored_stream.write_timeout(), None);
+
+            std::mem::drop(restored_stream);
+        });
+    }
+
+    #[test]
+    fn tcp_stream_into_accepted_round_trip() {
+        // A connection is accepted and used on one executor, converted back to
+        // an AcceptedTcpStream with into_accepted(), migrated to a second
+        // executor, and resumed there - all on the same underlying fd.
+        let (stream_sender, stream_receiver) = shared_channel::new_bounded(1);
+        let (addr_sender, addr_receiver) = shared_channel::new_bounded(1);
+
+        // ex1: accept, do the first exchange, then hand the live connection off.
+        let ex1 = LocalExecutorBuilder::default()
+            .spawn(move || async move {
+                let stream_sender = stream_sender.connect().await;
+                let addr_sender = addr_sender.connect().await;
+                let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+                addr_sender
+                    .try_send(listener.local_addr().unwrap())
+                    .unwrap();
+
+                let mut stream = listener.accept().await.unwrap();
+                let mut buf = [0u8; 4];
+                stream.read_exact(&mut buf).await.unwrap();
+                assert_eq!(&buf, b"ping");
+                stream.write_all(b"pong").await.unwrap();
+
+                // Dispose of glommio state but keep the fd open, then migrate it.
+                stream_sender.try_send(stream.into_accepted()).unwrap();
+            })
+            .unwrap();
+
+        // ex2: bind the migrated connection and resume the same TCP session.
+        let ex2 = LocalExecutorBuilder::default()
+            .spawn(move || async move {
+                let stream_receiver = stream_receiver.connect().await;
+                let accepted = stream_receiver.recv().await.unwrap();
+                let mut stream = accepted.bind_to_executor();
+
+                let mut buf = [0u8; 5];
+                stream.read_exact(&mut buf).await.unwrap();
+                assert_eq!(&buf, b"hello");
+                stream.write_all(b"world").await.unwrap();
+            })
+            .unwrap();
+
+        // ex3: client driving both stages over a single connection.
+        let ex3 = LocalExecutorBuilder::default()
+            .spawn(move || async move {
+                let addr_receiver = addr_receiver.connect().await;
+                let addr = addr_receiver.recv().await.unwrap();
+                let mut client = TcpStream::connect(addr).await.unwrap();
+
+                client.write_all(b"ping").await.unwrap();
+                let mut buf = [0u8; 4];
+                client.read_exact(&mut buf).await.unwrap();
+                assert_eq!(&buf, b"pong");
+
+                client.write_all(b"hello").await.unwrap();
+                let mut buf = [0u8; 5];
+                client.read_exact(&mut buf).await.unwrap();
+                assert_eq!(&buf, b"world");
+            })
+            .unwrap();
+
+        ex1.join().unwrap();
+        ex2.join().unwrap();
+        ex3.join().unwrap();
     }
 }


### PR DESCRIPTION
New feature related to moving work between shards. The basic flow is: 

1. SO_REUSEPORT means new client connections land on any shard
2. shard reads payload and decides which shard needs to handle the work
3. clean up the TcpStream, keeping the fd handle and the payload (now deserialised in-memory)
4. shunt it over to the right shard using the channel mesh
5. destination shard picks it up and creates another TcpStream object with the fd (used for response)

Demo server/code is here:
https://github.com/utilitydelta/glommio-sharded-affinity-server-starter

Been running it on Celeriant on chaos/soak >8hrs and its solid. Including everyone so we can comment on anything meta (how we manage new PRs, how we handle new functionality being added, etc)
