### PR TITLE
ci: update Rust checks and add full musl support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [net]
 git-fetch-with-cli = true
+
+[target.x86_64-unknown-linux-musl]
+linker = "musl-gcc"

--- a/.github/actions/cache-setup/action.yml
+++ b/.github/actions/cache-setup/action.yml
@@ -6,25 +6,41 @@ inputs: {}
 outputs: {}
 
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Version information
-      run: rustc --version; cargo --version; rustup --version
+      id: versions
       shell: bash
+      run: |
+        set -euo pipefail
+
+        rustc --version
+        cargo --version
+        rustup --version
+
+        rustc_hash="$(
+          rustc --version --verbose |
+            sha256sum |
+            cut -d ' ' -f 1
+        )"
+
+        echo "rustc-hash=$rustc_hash" >> "$GITHUB_OUTPUT"
 
     - name: Calculate dependencies
-      run: cargo generate-lockfile
       shell: bash
+      run: cargo generate-lockfile
 
-    - name: Cache
-      uses: actions/cache@v4
+    - name: Restore Rust cache
+      uses: actions/cache@v5
       with:
         path: |
-          ~/.cargo/bin/
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-          target/debug/.fingerprint
-          target/debug/build
-          target/debug/dep
-        key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          target/debug/.fingerprint/
+          target/debug/build/
+          target/debug/deps/
+          target/debug/incremental/
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-cargo-${{ steps.versions.outputs.rustc-hash }}-${{ hashFiles('Cargo.lock') }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-cargo-${{ steps.versions.outputs.rustc-hash }}-${{ hashFiles('Cargo.lock') }}-

--- a/.github/actions/setup-musl/action.yml
+++ b/.github/actions/setup-musl/action.yml
@@ -1,0 +1,57 @@
+name: Set up musl
+description: Install musl, the Rust target, and Linux UAPI headers
+
+runs:
+  using: composite
+  steps:
+    - name: Install packages and Rust target
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        sudo apt-get update
+        sudo apt-get install --yes \
+          build-essential \
+          musl-tools \
+          linux-libc-dev
+
+        rustup target add x86_64-unknown-linux-musl
+
+    - name: Expose Linux UAPI headers
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        musl_include=/usr/include/x86_64-linux-musl
+
+        sudo ln -sfn \
+          /usr/include/linux \
+          "${musl_include}/linux"
+
+        sudo ln -sfn \
+          /usr/include/asm-generic \
+          "${musl_include}/asm-generic"
+
+        sudo ln -sfn \
+          /usr/include/x86_64-linux-gnu/asm \
+          "${musl_include}/asm"
+
+    - name: Configure musl compiler
+      shell: bash
+      run: |
+        {
+          echo 'CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc'
+          echo 'CC_x86_64_unknown_linux_musl=musl-gcc'
+          echo 'AR_x86_64_unknown_linux_musl=ar'
+        } >>"${GITHUB_ENV}"
+
+    - name: Validate Linux UAPI headers
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        printf '#include <linux/swab.h>\n' |
+          musl-gcc -E -x c - >/dev/null
+
+        printf '#include <linux/io_uring.h>\n' |
+          musl-gcc -E -x c - >/dev/null

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="${1:-}"
+test_threads="$(nproc)"
+
+sudo -E \
+    PATH="${PATH}:/usr/share/rust/.cargo/bin" \
+    TEST_TARGET="${target}" \
+    TEST_THREADS="${test_threads}" \
+    bash -c '
+        set -euo pipefail
+
+        ulimit -Sl 512
+        ulimit -Hl 512
+
+        echo "${TEST_THREADS} CPU(s) available"
+        echo "PATH=${PATH}"
+        rustup show
+
+        args=(
+            test
+            --locked
+        )
+
+        if [[ -n "${TEST_TARGET}" ]]; then
+            args+=(--target "${TEST_TARGET}")
+        fi
+
+        exec cargo "${args[@]}" -- \
+            --test-threads="${TEST_THREADS}"
+    '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,92 +4,120 @@ permissions: write-all
 
 on:
   pull_request:
-    branches: [ main ]
-    types: [ "opened", "synchronize" ]
+    branches: [main]
+    types: [opened, synchronize, reopened]
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
-
   doc:
+    name: Documentation
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      # See https://github.com/rust-lang/rust/issues/148431
+      - name: Use Rust 1.93 for documentation
+        run: rustup override set 1.93.0
 
       - name: Cache setup
         uses: ./.github/actions/cache-setup
 
       - name: Install cargo-deadlinks
-        run: which deadlinks || cargo install cargo-deadlinks
+        run: which cargo-deadlinks || cargo install --locked cargo-deadlinks
 
       - name: Generate documentation
-        run: cargo doc --all
+        env:
+          RUSTDOCFLAGS: >-
+            --cfg zerocopy_unstable_ptr
+            -D rustdoc::broken_intra_doc_links
+        run: |
+          cargo clean --doc
+          cargo doc --workspace --all-features --locked
 
       - name: Validate links
         run: cargo deadlinks --dir target/doc/glommio
 
   lint:
+    name: Lint
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Cache setup
-      uses: ./.github/actions/cache-setup
-    - run: cargo fmt --all -- --check
-    - run: cargo clippy --all --all-targets --all-features
-    - run: cargo install cargo-sort
-    - run: cargo sort -w -c 
 
-  build:
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Cache setup
+        uses: ./.github/actions/cache-setup
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --workspace --all-targets --all-features --locked
+
+      - name: Install cargo-sort
+        run: which cargo-sort || cargo install --locked cargo-sort
+
+      - name: Check Cargo.toml ordering
+        run: cargo sort --workspace --check
+
+  build-and-test:
+    name: Build and Test (${{ matrix.name }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: glibc
+            target: ""
+            musl: false
+
+          - name: musl
+            target: x86_64-unknown-linux-musl
+            musl: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Set up musl
+        if: matrix.musl
+        uses: ./.github/actions/setup-musl
 
       - name: Cache setup
         uses: ./.github/actions/cache-setup
 
       - name: Build all targets
-        run: cargo build --all --all-targets
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Cache setup
-        uses: ./.github/actions/cache-setup
-
-      - name: Install cargo helpers and test all targets
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
-          cat << EOF > "run-gha-workflow.sh"
-          PATH=$PATH:/usr/share/rust/.cargo/bin
-          echo "`nproc` CPU(s) available"
-          rustup install 1.92
-          rustup show
-          rustup default stable
-          cargo install cargo-sort
-          cargo test -- --test-threads=`nproc`
-          EOF
-          sudo -E bash -c "ulimit -Sl 512 && ulimit -Hl 512 && bash run-gha-workflow.sh"
+          set -euo pipefail
 
-  build-musl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
+          args=(
+            build
+            --workspace
+            --all-targets
+            --locked
+          )
 
-      - name: Install cross
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cross
+          if [[ -n "${TARGET}" ]]; then
+            args+=(--target "${TARGET}")
+          fi
 
-      - name: Build for musl target
-        run: cross build --target x86_64-unknown-linux-musl
+          cargo "${args[@]}"
 
-      - name: Run tests for musl target
-        continue-on-error: true
-        run: cross test --target x86_64-unknown-linux-musl -- --test-threads=$(nproc) --skip io::dma_file::test
+      - name: Run tests
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: .github/scripts/run-tests.sh "${TARGET}"

--- a/glommio/src/iou/registrar/mod.rs
+++ b/glommio/src/iou/registrar/mod.rs
@@ -248,7 +248,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Device or resource busy")]
+    #[cfg_attr(target_env = "musl", should_panic(expected = "Resource busy"))]
+    #[cfg_attr(
+        not(target_env = "musl"),
+        should_panic(expected = "Device or resource busy")
+    )]
     fn double_register() {
         let ring = IoUring::new(1).unwrap();
         let _ = ring.registrar().register_files(&[1]).unwrap();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.92.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]
+targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
## What does this PR do?

Update the Rust CI checks and add native x86_64-unknown-linux-musl build and test coverage.

- Adds a pinned Rust toolchain with the required components and the musl target.
- Adds a reusable musl setup action for Ubuntu runners.
- Configures the musl linker and Linux UAPI headers required by the bundled liburing.
- Builds and tests both glibc and musl targets.
- Update GitHub Actions dependencies.
- Improves Cargo cache keying and restores target-specific build artefacts.
- Fixes documentation deadlinks.
- Fix cargo-sort linting errors.
- handles the (glibc/musl)-specific EBUSY message used by the double_register test

## Motivation

Broken CI restricting progress of development, seen in glommio/pull/25

## Testing Done

All CI tests pass.