### PR TITLE
Add support for async getdents

### DIFF
--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -6,6 +6,7 @@
 
 use crate::{
     io::{glommio_file::GlommioFile, read_result::ReadResult, OpenOptions},
+    sys::Statx,
     GlommioError,
 };
 use std::{
@@ -253,6 +254,11 @@ impl BufferedFile {
     /// once.
     pub async fn stat(&self) -> Result<Stat> {
         self.file.statx().await.map(Into::into)
+    }
+
+    /// Performs a statx operation on a file
+    pub async fn statx(&self) -> Result<Statx> {
+        self.file.statx().await
     }
 
     /// Closes this file.

--- a/glommio/src/io/directory.rs
+++ b/glommio/src/io/directory.rs
@@ -5,12 +5,17 @@
 //
 use crate::{
     io::{dma_file::DmaFile, glommio_file::GlommioFile},
-    sys, GlommioError,
+    sys::{self, SourceType},
+    GlommioError,
 };
 use std::{
     cell::Ref,
+    ffi::{CStr, OsStr},
     io,
-    os::unix::io::{AsRawFd, FromRawFd, RawFd},
+    os::unix::{
+        ffi::OsStrExt,
+        io::{AsRawFd, FromRawFd, RawFd},
+    },
     path::Path,
 };
 
@@ -25,6 +30,98 @@ pub struct Directory {
 impl AsRawFd for Directory {
     fn as_raw_fd(&self) -> RawFd {
         self.file.as_raw_fd()
+    }
+}
+
+const DIR_ENTRY_MIN_SIZE: usize = 18;
+
+/// Represents a readonly view into a dirent64
+///
+///     struct linux_dirent64 {
+///         ino64_t        d_ino;    /* 64-bit inode number */           off=0
+///         off64_t        d_off;    /* Not an offset; see getdents() */ off=8
+///         unsigned short d_reclen; /* Size of this dirent */           off=16
+///         unsigned char  d_type;   /* File type */                     off=18
+///         char           d_name[]; /* Filename (null-terminated) */    off=19
+///     };
+#[derive(Debug)]
+pub struct DirEntry64<'a> {
+    buf: &'a [u8],
+}
+
+impl<'a> DirEntry64<'a> {
+    pub(crate) fn new(buf: &'a [u8]) -> Self {
+        DirEntry64 { buf }
+    }
+
+    pub fn d_ino(&self) -> u64 {
+        u64::from_ne_bytes(self.buf[..8].try_into().unwrap())
+    }
+
+    pub fn d_type(&self) -> u8 {
+        self.buf[18]
+    }
+
+    pub fn d_reclen(&self) -> usize {
+        u16::from_ne_bytes(self.buf[16..18].try_into().unwrap()) as usize
+    }
+
+    pub fn d_name(&self) -> std::result::Result<&'a OsStr, std::ffi::FromBytesUntilNulError> {
+        // According to the getdents64(2) manual, d_name is null terminated.
+        // Thus, we construct an intermediate CStr as a validation step.
+        let c_str = CStr::from_bytes_until_nul(&self.buf[19..])?;
+        Ok(OsStr::from_bytes(c_str.to_bytes()))
+    }
+}
+
+#[derive(Debug)]
+pub struct DirEntryIter<'a> {
+    buf: &'a [u8],
+    i: usize,
+}
+
+/// An iterator over a list of dentries returned by getdents64
+impl<'a> Iterator for DirEntryIter<'a> {
+    type Item = DirEntry64<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let dentry_slice = self.buf.get(self.i..self.i + DIR_ENTRY_MIN_SIZE)?;
+
+        let dentry = DirEntry64::new(dentry_slice);
+
+        let reclen = dentry.d_reclen();
+        if reclen == 0 {
+            panic!("reclen is 0");
+        }
+
+        let dentry_slice = self.buf.get(self.i..self.i + reclen)?;
+
+        let dentry = DirEntry64::new(dentry_slice);
+
+        self.i += reclen;
+
+        Some(dentry)
+    }
+}
+
+impl<'a> DirEntryIter<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, i: 0 }
+    }
+}
+
+/// Represents the return value of getdents64(2)
+#[derive(Debug)]
+pub struct GetDents {
+    pub buf: Box<[u8]>,
+
+    /// Number of bytes the getdents64 call populated in buf
+    pub n: usize,
+}
+
+impl GetDents {
+    pub fn iter(&self) -> DirEntryIter<'_> {
+        DirEntryIter::new(&self.buf[..self.n])
     }
 }
 
@@ -114,6 +211,25 @@ impl Directory {
         DmaFile::create(path).await
     }
 
+    /// Read a list of dirent64s into buf, which is then returned in GetDents
+    pub async fn get_dents(&self, buf: Box<[u8]>) -> Result<GetDents> {
+        let res = crate::executor()
+            .reactor()
+            .get_dents(self.as_raw_fd(), buf)
+            .await;
+
+        let n = res.collect_rw().await?;
+
+        let buf = match res.extract_source_type() {
+            SourceType::GetDents(_, Some(buf)) => buf,
+            _ => unreachable!(
+                "a successful get_dents call should return a SourceType::GetDents(fd, Some(buf))"
+            ),
+        };
+
+        Ok(GetDents { buf, n })
+    }
+
     /// Returns an iterator to the contents of this directory
     pub fn sync_read_dir(&self) -> Result<std::fs::ReadDir> {
         let path = self.file.path_required("read directory")?;
@@ -149,5 +265,96 @@ fn contains_dir(path: &Path) -> bool {
     match iter.next() {
         Some(std::path::Component::Normal(_)) => iter.next().is_some(),
         _ => true,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashSet;
+
+    use super::*;
+    use crate::test_utils::*;
+
+    #[test]
+    fn directory_get_dents() {
+        test_executor!(async move {
+            let test_dir = make_tmp_test_directory("get_dents_testing");
+            let dir = Directory::open(test_dir.path.clone()).await.unwrap();
+            let buf = vec![0u8; 1024].into_boxed_slice();
+
+            let f1 = dir.create_file("f1").await.unwrap();
+            let f2 = dir.create_file("f2").await.unwrap();
+
+            let f1_stat = f1.statx().await.unwrap();
+            let f2_stat = f2.statx().await.unwrap();
+
+            let names = HashSet::from([".", "..", "f1", "f2"]);
+
+            let dents = dir.get_dents(buf).await.unwrap();
+
+            let mut actual_names = HashSet::new();
+            for dent in dents.iter() {
+                actual_names.insert(dent.d_name().unwrap().to_str().unwrap());
+
+                if dent.d_name().unwrap() == "f1" {
+                    assert_eq!(f1_stat.stx_ino, dent.d_ino());
+                }
+
+                if dent.d_name().unwrap() == "f2" {
+                    assert_eq!(f2_stat.stx_ino, dent.d_ino());
+                }
+            }
+
+            assert_eq!(actual_names, names);
+        });
+    }
+
+    #[test]
+    fn directory_dirent_iter_empty() {
+        let buf = vec![0u8; 0].into_boxed_slice();
+        let iter = DirEntryIter::new(&buf);
+        assert_eq!(iter.count(), 0);
+    }
+
+    #[test]
+    fn directory_dirent_iter_buffer_too_small_for_reclen() {
+        let mut buf = vec![0u8; 24];
+
+        let reclen: u16 = 40;
+        buf[16..18].copy_from_slice(&reclen.to_ne_bytes());
+
+        let mut iter = DirEntryIter::new(&buf);
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "reclen is 0")]
+    fn directory_dirent_iter_zero_reclen_panics() {
+        let mut buf = vec![0u8; DIR_ENTRY_MIN_SIZE];
+        let reclen: u16 = 0;
+        buf[16..18].copy_from_slice(&reclen.to_ne_bytes());
+
+        let mut iter = DirEntryIter::new(&buf);
+        let _ = iter.next(); // This should trigger the assert_ne!(reclen, 0)
+    }
+
+    #[test]
+    fn directory_dirent_missing_null_terminator() {
+        let mut buf = vec![0u8; 22];
+
+        let reclen: u16 = 22;
+        buf[16..18].copy_from_slice(&reclen.to_ne_bytes());
+
+        buf[19] = b'a';
+        buf[20] = b'b';
+        buf[21] = b'c';
+
+        let mut iter = DirEntryIter::new(&buf);
+        let entry = iter
+            .next()
+            .expect("Should still parse out the entry from the slice");
+
+        let name_result = entry.d_name();
+        assert!(name_result.is_err());
     }
 }

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -5,16 +5,12 @@
 //
 use crate::{
     io::{
-        bulk_io::{
+        ScheduledSource, bulk_io::{
             CoalescedReads, IoVec, MergedBufferLimit, OrderedBulkIo, ReadAmplificationLimit,
             ReadManyArgs, ReadManyResult,
-        },
-        glommio_file::GlommioFile,
-        open_options::OpenOptions,
-        read_result::ReadResult,
-        ScheduledSource,
+        }, glommio_file::GlommioFile, open_options::OpenOptions, read_result::ReadResult
     },
-    sys::{self, sysfs, DirectIo, DmaBuffer, DmaSource, PollableStatus},
+    sys::{self, DirectIo, DmaBuffer, DmaSource, PollableStatus, Statx, sysfs},
 };
 use futures_lite::{Stream, StreamExt};
 use nix::sys::statfs::*;
@@ -679,6 +675,11 @@ impl DmaFile {
     /// Returns the size of the filesystem cluster, in bytes
     pub async fn stat(&self) -> Result<Stat> {
         self.file.statx().await.map(Into::into)
+    }
+
+    /// Performs a statx operation on a file
+    pub async fn statx(&self) -> Result<Statx> {
+        self.file.statx().await
     }
 
     /// Tries to acquire a process-wide advisory shared lock on this file instance. If an exclusive advisory lock is

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -659,6 +659,16 @@ impl Reactor {
         }
     }
 
+    pub(crate) fn get_dents(&self, fd: RawFd, buf: Box<[u8]>) -> impl Future<Output = Source> {
+        let source = self.new_source(-1, SourceType::GetDents(fd, Some(buf)), None);
+        let waiter = self.sys.get_dents(&source);
+
+        async move {
+            waiter.await;
+            source
+        }
+    }
+
     pub(crate) fn run_blocking(
         &self,
         func: Box<dyn FnOnce() + Send + 'static>,

--- a/glommio/src/sys/blocking.rs
+++ b/glommio/src/sys/blocking.rs
@@ -35,6 +35,20 @@ macro_rules! raw_syscall {
     }};
 }
 
+macro_rules! raw_syscall_buf {
+    ($fn:ident $args:tt, $buf:expr) => {{
+        let res = unsafe { libc::$fn $args };
+        if res == -1 {
+            BlockingThreadResult::SyscallBuf(
+                -std::io::Error::last_os_error().raw_os_error().unwrap() as i64,
+                $buf,
+            )
+        } else {
+            BlockingThreadResult::SyscallBuf(res as i64, $buf, )
+        }
+    }};
+}
+
 fn to_result(res: i64) -> io::Result<usize> {
     if res < 0 {
         Err(std::io::Error::from_raw_os_error(-res as i32))
@@ -125,6 +139,7 @@ impl BlockingThreadOp {
 #[derive(Debug)]
 pub(super) enum BlockingThreadResult {
     Syscall(i64),
+    SyscallBuf(i64, Box<[u8]>),
     Fn,
 }
 
@@ -135,6 +150,7 @@ impl TryFrom<BlockingThreadResult> for std::io::Result<usize> {
         match value {
             BlockingThreadResult::Syscall(x) => Ok(to_result(x)),
             BlockingThreadResult::Fn => Ok(Ok(0)),
+            BlockingThreadResult::SyscallBuf(x, _) => Ok(to_result(x)),
         }
     }
 }
@@ -265,10 +281,24 @@ impl BlockingThreadPool {
 
             let src = waiters.remove(&id).unwrap();
             let mut inner_source = src.borrow_mut();
-            inner_source.wakers.result.replace(
-                res.try_into()
-                    .expect("not a valid blocking operation's result"),
-            );
+
+            match res {
+                BlockingThreadResult::Syscall(_) | BlockingThreadResult::Fn => {
+                    inner_source.wakers.result.replace(
+                        res.try_into()
+                            .expect("not a valid blocking operation's result"),
+                    );
+                }
+                BlockingThreadResult::SyscallBuf(raw, buf) => {
+                    match &mut inner_source.source_type {
+                        SourceType::GetDents(_fd, buf_slot) => {
+                            *buf_slot = Some(buf);
+                        }
+                        _ => panic!(),
+                    }
+                    inner_source.wakers.result.replace(to_result(raw));
+                }
+            }
             inner_source.wakers.wake_waiters();
 
             woke += 1;

--- a/glommio/src/sys/blocking.rs
+++ b/glommio/src/sys/blocking.rs
@@ -1,6 +1,6 @@
 use crate::{
     executor::bind_to_cpu_set,
-    sys::{InnerSource, SleepNotifier},
+    sys::{InnerSource, SleepNotifier, SourceType},
     PoolPlacement,
 };
 use ahash::AHashMap;
@@ -78,6 +78,7 @@ pub(super) enum BlockingThreadOp {
     CreateDir(PathBuf, libc::c_int),
     Truncate(RawFd, i64),
     CopyFileRange(RawFd, i64, RawFd, i64, usize),
+    GetDents(RawFd, Box<[u8]>),
     Fn(Box<dyn FnOnce() + Send + 'static>),
 }
 
@@ -94,6 +95,9 @@ impl Debug for BlockingThreadOp {
                 f,
                 "copy_file_range `{fd_in}` @ `{off_in}` -> {fd_out} @ `{off_out}` for {len} bytes"
             ),
+            BlockingThreadOp::GetDents(fd, buf) => {
+                write!(f, "getdents on `{fd}` into buffer {buf:?}")
+            }
             BlockingThreadOp::Fn(_) => write!(f, "user function"),
         }
     }
@@ -127,6 +131,11 @@ impl BlockingThreadOp {
                     len,
                     0
                 ))
+            }
+            BlockingThreadOp::GetDents(fd, mut buf) => {
+                let len = buf.len();
+                let pointer = buf.as_mut_ptr() as *mut libc::c_void;
+                raw_syscall_buf!(syscall(libc::SYS_getdents64, fd, pointer, len), buf)
             }
             BlockingThreadOp::Fn(f) => {
                 f();

--- a/glommio/src/sys/source.rs
+++ b/glommio/src/sys/source.rs
@@ -64,6 +64,7 @@ pub(crate) enum SourceType {
     BlockingFn,
     Invalid,
     CopyFileRange(RawFd, u64, usize),
+    GetDents(RawFd, Option<Box<[u8]>>),
     #[cfg(feature = "bench")]
     Noop,
 }

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -18,7 +18,7 @@ use std::{
     ffi::CStr,
     fmt,
     future::Future,
-    io,
+    io::{self, Read},
     ops::Range,
     os::unix::io::RawFd,
     panic,
@@ -1617,6 +1617,21 @@ impl Reactor {
 
         let op = BlockingThreadOp::Remove(path);
         self.enqueue_blocking_request(source.inner.clone(), op)
+    }
+
+    pub(crate) fn get_dents(&self, source: &Source) -> impl Future<Output = ()> {
+        let inner = source.inner.clone();
+        let (fd, buf) = match &mut *source.source_type_mut() {
+            SourceType::GetDents(fd, buf) => (
+                *fd,
+                buf.take().expect("get_dents call not provided with buffer"),
+            ),
+            _ => panic!("Unexpected source for getdents operation"),
+        };
+
+        let op = BlockingThreadOp::GetDents(fd, buf);
+
+        self.enqueue_blocking_request(inner, op)
     }
 
     pub(crate) fn run_blocking(


### PR DESCRIPTION
### What does this PR do?

This PR adds an async interface to the linux getdents64 syscall. The prerequisite commits add support for an async statx routine as well as boilerplate for blocking syscall routines that write to an output buffer. These two can be split into separate PRs if desired.

### Motivation

The current directory entry retrieval method is fully synchronous.

### Related issues

None

### Additional Notes

I make the assumption that the file descriptor returned by `Directory` is open and unchanging for the lifetime of the object. Filesystems keep track of the getdents offset internally. If the file descriptor reopens during the lifetime of the object, the fix is just a matter of running lseek on the descriptor before getdents is called, though this adds overhead.

The new blocking result adds a `Option<Box<[u8]>>` IO buffer. The idea is that buffer is taken from the input source during the input stage of the routine and put back during the output stage. Suggestions on where this can improve are highly welcome.

### Checklist

[x] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[x] If applicable, I have discussed my architecture
