### PR TITLE
fix: don't abort the process when a task panics in a custom queue

### DIFF
--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -1089,19 +1089,28 @@ impl<T> PoolThreadHandles<T> {
 
 pub(crate) fn maybe_activate(tq: Rc<RefCell<TaskQueue>>) {
     #[cfg(any(not(nightly), not(feature = "native-tls")))]
-    LOCAL_EX.with(|local_ex| {
-        let mut queues = local_ex.queues.borrow_mut();
-        queues.maybe_activate(tq);
-    });
+    {
+        // A task that panics unwinds through this path while the executor is
+        // already tearing down, and by then the thread-local may be gone.
+        // Reaching for it unconditionally panics a second time, and a panic
+        // during a panic aborts the process. There is nothing to activate at
+        // that point anyway, so skipping is both safe and correct.
+        if LOCAL_EX.is_set() {
+            LOCAL_EX.with(|local_ex| {
+                let mut queues = local_ex.queues.borrow_mut();
+                queues.maybe_activate(tq);
+            });
+        }
+    }
 
     #[cfg(all(nightly, feature = "native-tls"))]
     unsafe {
-        let mut queues = LOCAL_EX
-            .as_ref()
-            .expect("this thread doesn't have a LocalExecutor running")
-            .queues
-            .borrow_mut();
-        queues.maybe_activate(tq);
+        // Same reasoning as above: null means no executor is installed on this
+        // thread, which happens while unwinding out of a panicked task.
+        if let Some(local_ex) = LOCAL_EX.as_ref() {
+            let mut queues = local_ex.queues.borrow_mut();
+            queues.maybe_activate(tq);
+        }
     };
 }
 

--- a/glommio/tests/task_panic_in_custom_queue.rs
+++ b/glommio/tests/task_panic_in_custom_queue.rs
@@ -1,0 +1,140 @@
+// Integration test for issue #689 - Task panic in non-default queue causes process abort
+// This test verifies that when a task panics in a custom task queue, the panic is
+// handled gracefully without aborting the process
+
+// The tests below all exercise spawn_local_into, so everything they import is
+// only in scope under the same feature gate.
+use futures::join;
+use glommio::{Latency, LocalExecutorBuilder, Placement, Shares};
+use std::panic;
+use std::time::Duration;
+
+// These tests require spawn_local_into (unsafe detached spawn)
+#[test]
+fn test_panic_in_default_queue() {
+    // This should work - panic in default queue is handled correctly
+    let ex = LocalExecutorBuilder::new(Placement::Fixed(0))
+        .make()
+        .unwrap();
+
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        ex.run(async move {
+            let tq = glommio::executor().current_task_queue();
+            let task1 = glommio::spawn_local_into(
+                async move {
+                    glommio::timer::sleep(Duration::from_millis(1)).await;
+                    panic!("intentional panic in default queue");
+                },
+                tq,
+            )
+            .unwrap();
+
+            let task2 = glommio::spawn_local_into(
+                async move {
+                    glommio::timer::sleep(Duration::from_secs(10)).await;
+                },
+                tq,
+            )
+            .unwrap();
+
+            join!(task1, task2);
+        });
+    }));
+
+    assert!(result.is_err(), "Expected panic to be caught");
+}
+
+#[test]
+fn test_panic_in_custom_queue() {
+    // This is the critical test - panic in custom queue should NOT abort process
+    // Before fix: This would abort the entire process
+    // After fix: Panic should be caught and handled gracefully
+    let ex = LocalExecutorBuilder::new(Placement::Fixed(0))
+        .make()
+        .unwrap();
+
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        ex.run(async move {
+            // Create custom task queue - this is the key difference from test above
+            let tq = glommio::executor().create_task_queue(
+                Shares::Static(10),
+                Latency::NotImportant,
+                "custom queue",
+            );
+
+            let task1 = glommio::spawn_local_into(
+                async move {
+                    glommio::timer::sleep(Duration::from_millis(1)).await;
+                    panic!("intentional panic in custom queue");
+                },
+                tq,
+            )
+            .unwrap();
+
+            let task2 = glommio::spawn_local_into(
+                async move {
+                    glommio::timer::sleep(Duration::from_secs(10)).await;
+                },
+                tq,
+            )
+            .unwrap();
+
+            join!(task1, task2);
+        });
+    }));
+
+    // The key assertion: panic should be caught, NOT abort the process
+    assert!(
+        result.is_err(),
+        "Expected panic to be caught in custom queue without aborting process"
+    );
+}
+
+#[test]
+fn test_multiple_panics_in_custom_queues() {
+    // Test multiple custom queues with panics
+    let ex = LocalExecutorBuilder::new(Placement::Fixed(0))
+        .make()
+        .unwrap();
+
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        ex.run(async move {
+            let tq1 = glommio::executor().create_task_queue(
+                Shares::Static(10),
+                Latency::NotImportant,
+                "queue 1",
+            );
+
+            let tq2 = glommio::executor().create_task_queue(
+                Shares::Static(10),
+                Latency::NotImportant,
+                "queue 2",
+            );
+
+            let task1 = glommio::spawn_local_into(
+                async move {
+                    glommio::timer::sleep(Duration::from_millis(1)).await;
+                    panic!("panic in queue 1");
+                },
+                tq1,
+            )
+            .unwrap();
+
+            let task2 = glommio::spawn_local_into(
+                async move {
+                    glommio::timer::sleep(Duration::from_millis(2)).await;
+                    panic!("panic in queue 2");
+                },
+                tq2,
+            )
+            .unwrap();
+
+            join!(task1, task2);
+        });
+    }));
+
+    assert!(
+        result.is_err(),
+        "Expected panics in multiple custom queues to be caught"
+    );
+}


### PR DESCRIPTION
Fixes #689 (carried over from DataDog/glommio).

## The bug

A task that panics unwinds through `maybe_activate`, which reaches for `LOCAL_EX` unconditionally. By that point the executor is already tearing down and the thread-local may be gone, so the lookup panics a second time. A panic during a panic is a non-unwinding panic, and the process aborts:

```
panic in a destructor during cleanup
thread caused non-unwinding panic. aborting.
SIGABRT
```

The default task queue happens to escape this, because its cleanup order leaves the thread-local intact — which is why the abort only shows up with a custom queue, and why the issue reads as queue-specific.

## The fix

Guard both cfg branches before touching `LOCAL_EX`. Once the executor is gone there is nothing to activate, so skipping is correct rather than merely defensive.

## Testing

Adds `glommio/tests/task_panic_in_custom_queue.rs` covering a panic in a custom queue, a panic in the default queue, and several panics across queues.

I checked the test actually catches the bug rather than just passing: reverting the fix and re-running produces the `SIGABRT` above. With the fix, all three pass.

`cargo build` and `cargo fmt` clean on top of `main`.

## Note

`clippy -D warnings` currently fails on pristine `main` with three errors, all from a missing doc comment on `GlommioError::into_inner`. Unrelated to this change, so I left it alone — happy to send a one-line follow-up if that's useful.