### PR TITLE
feat: make executor placement aware of cache domains

### DIFF
--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -670,29 +670,49 @@ where
         let nr_numa_node = Self::count_unique_by(&topology, |c| c.numa_node);
         let nr_package = Self::count_unique_by(&topology, |c| c.package);
 
+        // Cache domain ids must be unique across the whole tree, like every
+        // other level. They are not necessarily so as they arrive: a machine
+        // that reports no cache topology falls back to the package id, and if
+        // numa nodes nest inside packages that same id then appears under two
+        // different parents. Remap against the parents to guarantee it.
+        {
+            let mut dense = std::collections::BTreeMap::new();
+            for cpu in &topology {
+                let n = dense.len();
+                dense
+                    .entry((cpu.numa_node, cpu.package, cpu.cache_domain))
+                    .or_insert(n);
+            }
+            for cpu in &mut topology {
+                cpu.cache_domain = dense[&(cpu.numa_node, cpu.package, cpu.cache_domain)];
+            }
+        }
+
         // the topology must be sorted such that all children of a `Node` are added to a
         // parent consecutively
         let f_level: fn(&CpuLocation, usize) -> Level = if nr_package < nr_numa_node {
-            topology.sort_by_key(|l| (l.package, l.numa_node, l.core, l.cpu));
+            topology.sort_by_key(|l| (l.package, l.numa_node, l.cache_domain, l.core, l.cpu));
             |cpu_loc, depth| -> Level {
                 match depth {
                     0 => Level::SystemRoot,
                     1 => Level::Package(cpu_loc.package),
                     2 => Level::NumaNode(cpu_loc.numa_node),
-                    3 => Level::Core(cpu_loc.core),
-                    4 => Level::Cpu(cpu_loc.cpu),
+                    3 => Level::CacheDomain(cpu_loc.cache_domain),
+                    4 => Level::Core(cpu_loc.core),
+                    5 => Level::Cpu(cpu_loc.cpu),
                     _ => unreachable!("unexpected tree level: {depth}"),
                 }
             }
         } else {
-            topology.sort_by_key(|l| (l.numa_node, l.package, l.core, l.cpu));
+            topology.sort_by_key(|l| (l.numa_node, l.package, l.cache_domain, l.core, l.cpu));
             |cpu_loc, depth| -> Level {
                 match depth {
                     0 => Level::SystemRoot,
                     1 => Level::NumaNode(cpu_loc.numa_node),
                     2 => Level::Package(cpu_loc.package),
-                    3 => Level::Core(cpu_loc.core),
-                    4 => Level::Cpu(cpu_loc.cpu),
+                    3 => Level::CacheDomain(cpu_loc.cache_domain),
+                    4 => Level::Core(cpu_loc.core),
+                    5 => Level::Cpu(cpu_loc.cpu),
                     _ => unreachable!("unexpected tree level: {depth}"),
                 }
             }
@@ -756,7 +776,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::sys::hardware_topology::test_helpers::cpu_loc;
+    use crate::sys::hardware_topology::test_helpers::{cpu_loc, cpu_loc_cache};
 
     #[test]
     fn cpu_set() {
@@ -836,6 +856,69 @@ mod test {
 
         for _ in 0..n {
             let _cpu_location: CpuLocation = max_packer.next().unwrap();
+        }
+    }
+
+    /// A single-package, single-NUMA machine with four cache domains of two
+    /// cores each -- the shape of a current AMD desktop or Threadripper part,
+    /// and the shape that motivated the cache level. `package` and `numa_node`
+    /// are constant throughout, so any grouping below them can only come from
+    /// the cache domain.
+    fn topology_four_cache_domains() -> Vec<CpuLocation> {
+        let mut topology = Vec::new();
+        for domain in 0..4 {
+            for core in 0..2 {
+                let core = domain * 2 + core;
+                topology.push(cpu_loc_cache(0, 0, domain, core, core));
+            }
+        }
+        topology
+    }
+
+    #[test]
+    fn max_packer_fills_a_cache_domain_before_crossing() {
+        // Packing should exhaust one L3 domain before touching another;
+        // without a cache level it would have no reason to.
+        let mut packer = MaxPacker::from_topology(topology_four_cache_domains());
+        let first: Vec<usize> = (0..2).map(|_| packer.next().unwrap().cpu).collect();
+
+        let domain_of = |cpu: usize| cpu / 2;
+        assert_eq!(
+            domain_of(first[0]),
+            domain_of(first[1]),
+            "the first two shards landed in different cache domains: {first:?}"
+        );
+    }
+
+    #[test]
+    fn max_spreader_uses_every_cache_domain_first() {
+        // Spreading four shards over four domains should use each exactly once,
+        // rather than doubling up in one while another sits idle.
+        let mut spreader = MaxSpreader::from_topology(topology_four_cache_domains());
+        let mut per_domain = [0; 4];
+        for _ in 0..4 {
+            per_domain[spreader.next().unwrap().cpu / 2] += 1;
+        }
+        assert_eq!(
+            [1, 1, 1, 1],
+            per_domain,
+            "four shards did not land one per cache domain: {per_domain:?}"
+        );
+    }
+
+    #[test]
+    fn cache_domain_survives_the_round_trip() {
+        // The iterator yields CpuLocations rebuilt from a tree path, so the
+        // cache domain has to come back out intact.
+        let mut spreader = MaxSpreader::from_topology(topology_four_cache_domains());
+        for _ in 0..8 {
+            let loc = spreader.next().unwrap();
+            assert_eq!(
+                loc.cache_domain,
+                loc.cpu / 2,
+                "cache domain lost or garbled for cpu {}",
+                loc.cpu
+            );
         }
     }
 

--- a/glommio/src/executor/placement/pq_tree.rs
+++ b/glommio/src/executor/placement/pq_tree.rs
@@ -14,6 +14,10 @@ pub enum Level {
     SystemRoot,
     Cpu(usize),
     Core(usize),
+    /// The set of cores sharing a last-level cache. Sits below `Package`
+    /// because a package may contain several of them -- see
+    /// [`CpuLocation::cache_domain`].
+    CacheDomain(usize),
     Package(usize),
     NumaNode(usize),
 }
@@ -204,6 +208,7 @@ impl std::convert::TryFrom<Path> for CpuLocation {
     fn try_from(path: Path) -> Result<Self, Self::Error> {
         let mut cpu = None;
         let mut core = None;
+        let mut cache = None;
         let mut pkg = None;
         let mut numa = None;
 
@@ -217,6 +222,10 @@ impl std::convert::TryFrom<Path> for CpuLocation {
                 Level::Core(id) => match core {
                     None => core = Some(id),
                     Some(_) => return Err("duplicate core in path"),
+                },
+                Level::CacheDomain(id) => match cache {
+                    None => cache = Some(id),
+                    Some(_) => return Err("duplicate cache domain in path"),
                 },
                 Level::Package(id) => match pkg {
                     None => pkg = Some(id),
@@ -235,6 +244,9 @@ impl std::convert::TryFrom<Path> for CpuLocation {
                 core,
                 package,
                 numa_node,
+                // Trees built without a cache level (the test fixtures) yield
+                // no cache domain; fall back the same way the sysfs parser does.
+                cache_domain: cache.unwrap_or(package),
             }),
             _ => Err("Failed to construct Path from CpuLocation"),
         }

--- a/glommio/src/sys/hardware_topology.rs
+++ b/glommio/src/sys/hardware_topology.rs
@@ -27,6 +27,20 @@ pub struct CpuLocation {
     pub package: usize,
     /// Holds the NUMA node on which the `cpu` is located.
     pub numa_node: usize,
+    /// Holds the last-level cache domain in which the `cpu` sits, i.e. the set
+    /// of CPUs it shares an L3 with.
+    ///
+    /// This is a finer distinction than [`Self::package`] and on several
+    /// current parts it is the one that matters. A single-socket AMD
+    /// Threadripper reports one package and one NUMA node while physically
+    /// having four L3 domains, and moving a cache line between two of them
+    /// costs an order of magnitude more than keeping it inside one. Placement
+    /// that only knows about packages and NUMA nodes cannot see that
+    /// difference.
+    ///
+    /// Falls back to the package id when the kernel does not expose cache
+    /// topology, which reproduces the previous behaviour.
+    pub cache_domain: usize,
 }
 
 fn build_cpu_location(
@@ -46,7 +60,65 @@ fn build_cpu_location(
         core: get_core_id(cpu, &cpu_path, cpu_to_core)?,
         package: package_id,
         numa_node,
+        // Provisional: replaced with a dense id below, or left as the package
+        // id if this machine does not report cache topology.
+        cache_domain: get_cache_domain_id(sysfs_path, cpu).unwrap_or(package_id),
     })
+}
+
+/// Identifies the last-level cache domain `cpu` belongs to.
+///
+/// Walks `cpu/cpuN/cache/index*`, takes the highest cache level reported, and
+/// canonicalises the domain as the lowest CPU id sharing it -- so every CPU in
+/// a domain derives the same value without any cross-CPU coordination. Returns
+/// `None` when the machine does not expose cache topology at all (some
+/// containers, some architectures), in which case the caller falls back to the
+/// package.
+fn get_cache_domain_id(sysfs_path: &Path, cpu: usize) -> Option<usize> {
+    let cache_path = sysfs_path.join(format!("cpu/cpu{cpu}/cache"));
+    let mut best: Option<(usize, usize)> = None;
+
+    for entry in std::fs::read_dir(&cache_path).ok()? {
+        let dir = entry.ok()?.path();
+        if !dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("index"))
+        {
+            continue;
+        }
+
+        let level: usize = match std::fs::read_to_string(dir.join("level")) {
+            Ok(s) => match s.trim().parse() {
+                Ok(l) => l,
+                Err(_) => continue,
+            },
+            Err(_) => continue,
+        };
+
+        // Instruction caches are never the sharing domain we care about.
+        if matches!(
+            std::fs::read_to_string(dir.join("type"))
+                .as_deref()
+                .map(str::trim),
+            Ok("Instruction")
+        ) {
+            continue;
+        }
+
+        let Ok(shared) = ListIterator::from_path(&dir.join("shared_cpu_list")) else {
+            continue;
+        };
+        let Some(min_cpu) = shared.filter_map(Result::ok).min() else {
+            continue;
+        };
+
+        if best.is_none_or(|(best_level, _)| level > best_level) {
+            best = Some((level, min_cpu));
+        }
+    }
+
+    best.map(|(_, min_cpu)| min_cpu)
 }
 
 /// Request the machine topology.  Only CPUs that are currently `online`
@@ -125,6 +197,21 @@ pub fn get_machine_topology_unsorted() -> io::Result<Vec<CpuLocation>> {
 
     for cpu_location in &mut cpu_locations {
         cpu_location.core = *cpu_to_vcore.get(&cpu_location.cpu).unwrap();
+    }
+
+    // Densify cache domain ids the same way, and for the same reason: the
+    // placement tree assumes ids at a level are unique and consecutive, and the
+    // raw value so far is "lowest CPU sharing this cache", which is neither.
+    // BTreeMap keeps the mapping stable across invocations.
+    let raw_domains: std::collections::BTreeSet<usize> =
+        cpu_locations.iter().map(|l| l.cache_domain).collect();
+    let domain_to_dense: HashMap<usize, usize> = raw_domains
+        .into_iter()
+        .enumerate()
+        .map(|(dense, raw)| (raw, dense))
+        .collect();
+    for cpu_location in &mut cpu_locations {
+        cpu_location.cache_domain = domain_to_dense[&cpu_location.cache_domain];
     }
 
     Ok(cpu_locations)
@@ -230,12 +317,27 @@ pub(crate) mod test_helpers {
         }
     }
 
+    /// A CPU on a machine that reports no cache topology, so the cache domain
+    /// degenerates to the package. Existing tests use this, and their passing
+    /// is what shows the new level changes nothing on such machines.
     pub fn cpu_loc(numa_node: usize, package: usize, core: usize, cpu: usize) -> CpuLocation {
+        cpu_loc_cache(numa_node, package, package, core, cpu)
+    }
+
+    /// A CPU on a machine with several cache domains per package.
+    pub fn cpu_loc_cache(
+        numa_node: usize,
+        package: usize,
+        cache_domain: usize,
+        core: usize,
+        cpu: usize,
+    ) -> CpuLocation {
         CpuLocation {
             cpu,
             core,
             package,
             numa_node,
+            cache_domain,
         }
     }
 }

--- a/glommio/src/sys/hardware_topology.rs
+++ b/glommio/src/sys/hardware_topology.rs
@@ -372,3 +372,121 @@ mod test {
         check_topolgy(topology);
     }
 }
+
+#[cfg(test)]
+mod cache_domain_tests {
+    use super::get_cache_domain_id;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    /// A throwaway sysfs tree.
+    ///
+    /// The parsing under test takes the sysfs root as an argument precisely so
+    /// it can be pointed somewhere else, which is the only way to cover
+    /// topologies this machine does not have.
+    struct FakeSysfs(PathBuf);
+
+    impl FakeSysfs {
+        fn new() -> Self {
+            static NEXT: AtomicUsize = AtomicUsize::new(0);
+            let path = std::env::temp_dir().join(format!(
+                "glommio-topology-{}-{}",
+                std::process::id(),
+                NEXT.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir_all(&path).expect("create fixture root");
+            FakeSysfs(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+
+        /// Adds one cache index for `cpu`, as sysfs would expose it.
+        fn cache(&self, cpu: usize, index: usize, level: &str, kind: &str, shared: &str) -> &Self {
+            let dir = self.0.join(format!("cpu/cpu{cpu}/cache/index{index}"));
+            fs::create_dir_all(&dir).expect("create cache index");
+            // Trailing newlines, because sysfs has them and the list parser
+            // relies on it: `skip_delim` leaves the final byte alone so the
+            // terminator can be checked. A fixture without one hangs.
+            fs::write(dir.join("level"), format!("{level}\n")).expect("write level");
+            fs::write(dir.join("type"), format!("{kind}\n")).expect("write type");
+            fs::write(dir.join("shared_cpu_list"), format!("{shared}\n"))
+                .expect("write shared_cpu_list");
+            self
+        }
+    }
+
+    impl Drop for FakeSysfs {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn the_domain_is_the_lowest_cpu_sharing_the_deepest_cache() {
+        let sysfs = FakeSysfs::new();
+        // Two packages of four, sharing an L3 each.
+        for cpu in 0..8 {
+            let l3 = if cpu < 4 { "0-3" } else { "4-7" };
+            sysfs
+                .cache(cpu, 0, "1", "Data", &cpu.to_string())
+                .cache(cpu, 2, "3", "Unified", l3);
+        }
+
+        for cpu in 0..4 {
+            assert_eq!(get_cache_domain_id(sysfs.path(), cpu), Some(0), "cpu {cpu}");
+        }
+        for cpu in 4..8 {
+            assert_eq!(get_cache_domain_id(sysfs.path(), cpu), Some(4), "cpu {cpu}");
+        }
+    }
+
+    #[test]
+    fn an_instruction_cache_is_not_a_sharing_domain() {
+        let sysfs = FakeSysfs::new();
+        // An instruction cache reported at a deeper level than the unified one
+        // it shares a die with. Taking it would split a domain that is real.
+        sysfs
+            .cache(0, 0, "2", "Unified", "0-1")
+            .cache(0, 1, "3", "Instruction", "0");
+
+        assert_eq!(get_cache_domain_id(sysfs.path(), 0), Some(0));
+
+        let sysfs = FakeSysfs::new();
+        sysfs
+            .cache(1, 0, "2", "Unified", "0-1")
+            .cache(1, 1, "3", "Instruction", "1");
+
+        assert_eq!(
+            get_cache_domain_id(sysfs.path(), 1),
+            Some(0),
+            "the unified cache shared with cpu 0 decides the domain"
+        );
+    }
+
+    #[test]
+    fn a_machine_that_reports_no_cache_topology_has_no_domain() {
+        let sysfs = FakeSysfs::new();
+        // Some containers and some architectures expose no cache directory at
+        // all. The caller falls back to the package id.
+        assert_eq!(get_cache_domain_id(sysfs.path(), 0), None);
+    }
+
+    #[test]
+    fn an_unreadable_level_does_not_discard_the_rest() {
+        let sysfs = FakeSysfs::new();
+        sysfs
+            .cache(0, 0, "2", "Unified", "0-1")
+            .cache(0, 1, "not a number", "Unified", "0-7");
+
+        assert_eq!(
+            get_cache_domain_id(sysfs.path(), 0),
+            Some(0),
+            "the index that parsed still decides"
+        );
+    }
+}


### PR DESCRIPTION
Independent of my other open PRs (#29, #30) — touches only `placement/` and `hardware_topology.rs`, and applies to `main` on its own.

## Problem

`CpuLocation` models `cpu`, `core`, `package` and `numa_node`, and the placement tree runs `SystemRoot → NumaNode → Package → Core → Cpu`. Several current parts report **one package and one NUMA node while containing several last-level cache domains**, so placement can't distinguish arrangements that differ by an order of magnitude in communication cost.

Measured on a single-socket 32-core Threadripper with four L3 domains:

| | round trip |
|---|---:|
| cache line, same L3 domain | 42 ns |
| cache line, across L3 domains | **486 ns** |
| glommio shard-to-shard, same domain | 8.1 µs |
| glommio shard-to-shard, cross domain | **12.8 µs** |

Placement had no way to see that — every core reports package 0, node 0.

## Change

Adds a `cache_domain` field, read from the highest cache level sysfs reports and canonicalised as the lowest CPU sharing it, plus a `Level::CacheDomain` between `Package` and `Core`.

After it, on that machine:

| | domains touched |
|---|---|
| `MaxPack` at 2, 4, 8, 16 shards | **1** |
| `MaxSpread` at 4+ shards | **4** |

## Compatibility

A machine that reports no cache topology falls back to the package id and behaves exactly as before — which is what the **unchanged existing tests** demonstrate, since they all construct topologies through that path.

One subtlety worth flagging: that fallback isn't unique across parents when NUMA nodes nest inside packages, so `from_topology` remaps cache domains against `(numa_node, package)` before building the tree. Without it, two nodes in one package both claim domain 0 and the tree builder mis-nests them — caught by the existing `max_packer_numa_in_pkg` test.

**`CpuLocation` is public, so the new field is a breaking change** for callers constructing it literally. Flagging that explicitly since it's your semver call, not mine.

## Not changed

`MaxPack` still prefers SMT siblings, which measure slower than separate cores in the same domain (58.5 ns vs 42.5 ns ping-pong). That follows from its contract of minimising CPU footprint, so I left it alone — a communication-first policy would be a new placement, not a change to this one.

## Testing

31 placement tests pass, including 3 new ones for a machine with four cache domains in one package. `cargo fmt` clean. No clippy errors beyond the three already on `main` from `GlommioError::into_inner`.