### PR TITLE
perf: carry indices in the task header, not owned references

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -58,6 +58,7 @@ typenum               = "1.19"
 rustc_version = "0.4.1"
 
 [dev-dependencies]
+criterion = { version = "0.8.2", default-features = false, features = ["async", "cargo_bench_support"] }
 fastrand = "2.3"
 futures = "0.3"
 hdrhistogram = "7.5"
@@ -77,6 +78,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(nightly)'] }
+
+[[bench]]
+harness = false
+name    = "spawn"
 
 [[bench]]
 harness = false

--- a/glommio/benches/common/mod.rs
+++ b/glommio/benches/common/mod.rs
@@ -1,0 +1,19 @@
+//! Shared harness pieces for the benchmarks.
+
+use criterion::async_executor::AsyncExecutor;
+use glommio::LocalExecutor;
+use std::future::Future;
+
+/// Runs benchmark futures on one long-lived executor.
+///
+/// Building an executor costs microseconds because of the io_uring setup, so a
+/// fresh one per iteration would swamp anything measured in nanoseconds.
+/// `LocalExecutor::run` takes `&self`, so one executor serves every iteration.
+#[derive(Default)]
+pub struct Glommio(pub LocalExecutor);
+
+impl AsyncExecutor for &Glommio {
+    fn block_on<T>(&self, future: impl Future<Output = T>) -> T {
+        self.0.run(future)
+    }
+}

--- a/glommio/benches/spawn.rs
+++ b/glommio/benches/spawn.rs
@@ -1,0 +1,99 @@
+//! What a spawn costs, and what it costs when many cores spawn at once.
+//!
+//! The scaling group is the one that matters for a thread-per-core runtime:
+//! executors that share nothing at the application level should not slow each
+//! other down, so growth there is the runtime serialising cores against each
+//! other.
+
+mod common;
+
+use common::Glommio;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use glommio::{spawn_local, LocalExecutor};
+use std::{
+    hint::black_box,
+    sync::{Arc, Barrier},
+    time::{Duration, Instant},
+};
+
+fn spawn(c: &mut Criterion) {
+    let ex = Glommio::default();
+    let mut group = c.benchmark_group("spawn");
+
+    group.bench_function("spawn_local, awaited", |b| {
+        b.to_async(&ex)
+            .iter(|| async { black_box(spawn_local(async { 1u32 }).await) })
+    });
+
+    group.bench_function("spawn_local, detached", |b| {
+        b.to_async(&ex).iter(|| async {
+            // Not awaited on purpose: the cost being measured is spawn plus
+            // detach, not the task running to completion.
+            let handle = spawn_local(async { 1u32 }).detach();
+            black_box(handle);
+        })
+    });
+
+    // A capture large enough that the task is boxed rather than stored inline.
+    group.bench_function("spawn_local, 512B capture", |b| {
+        b.to_async(&ex).iter(|| async {
+            let payload = [0u8; 512];
+            black_box(spawn_local(async move { payload[0] }).await)
+        })
+    });
+
+    group.finish();
+}
+
+/// Per-spawn cost as a function of how many executors are spawning at once.
+///
+/// Timed by hand through `iter_custom` because the quantity is the wall time of
+/// a round across every thread, which criterion's per-iteration timing cannot
+/// express.
+fn spawn_scaling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("spawn_scaling");
+
+    for threads in [1usize, 2, 4, 8, 16, 32, 64] {
+        group.throughput(Throughput::Elements(threads as u64));
+        group.bench_function(BenchmarkId::from_parameter(threads), |b| {
+            b.iter_custom(|iters| {
+                let barrier = Arc::new(Barrier::new(threads));
+                let handles: Vec<_> = (0..threads)
+                    .map(|_| {
+                        let barrier = barrier.clone();
+                        std::thread::spawn(move || {
+                            let ex = LocalExecutor::default();
+                            ex.run(async move {
+                                // Warm the allocator and the task pool before
+                                // the measured window opens.
+                                for _ in 0..1_000 {
+                                    black_box(spawn_local(async { 1u32 }).await);
+                                }
+                                barrier.wait();
+
+                                let started = Instant::now();
+                                for _ in 0..iters {
+                                    black_box(spawn_local(async { 1u32 }).await);
+                                }
+                                started.elapsed()
+                            })
+                        })
+                    })
+                    .collect();
+
+                // The slowest thread is the round: a fast one that finished
+                // early was not contending for the rest of the window.
+                handles
+                    .into_iter()
+                    .map(|h| h.join().expect("executor thread"))
+                    .max()
+                    .unwrap_or(Duration::ZERO)
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, spawn, spawn_scaling);
+criterion_main!(benches);

--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -134,7 +134,14 @@ impl<T: BufferHalf> Future for Connector<T> {
             }
             // usize::MAX (the disconnected) always has a placeholder notifier that never
             // returns its fd. So if the other side disconnected it will unblock us here
-            id => Poll::Ready(sys::get_sleep_notifier_for(id).unwrap()),
+            id => Poll::Ready(sys::get_sleep_notifier_for(id).unwrap_or_else(|| {
+                // The id outlives the notifier: the peer's executor drops it on
+                // its own schedule, while the id stays until the peer half is.
+                // An executor that is gone cannot be woken, so it is disconnected.
+                self.buffer.disconnect_peer();
+                sys::get_sleep_notifier_for(usize::MAX)
+                    .expect("the disconnected notifier is a static and always exists")
+            })),
         }
     }
 }
@@ -485,16 +492,19 @@ impl<T: Send + Sized> Drop for ConnectedSender<T> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::LocalExecutor;
     use crate::{
         timer::{sleep, Timer},
         LocalExecutorBuilder, Placement,
     };
-    use futures_lite::{FutureExt, StreamExt};
+    use futures_lite::{future::poll_fn, FutureExt, StreamExt};
     use std::{
+        future::Future,
         sync::{
             atomic::{AtomicUsize, Ordering},
             mpsc, Arc,
         },
+        task::Poll,
         time::Duration,
     };
 
@@ -1010,5 +1020,30 @@ mod test {
 
         ex1.join().unwrap();
         ex2.join().unwrap();
+    }
+
+    #[test]
+    fn peer_connect_after_canceled_connection_and_retained_task_waker() {
+        let (sender, receiver) = new_bounded::<u8>(1);
+        let executor = LocalExecutor::default();
+        let retained_waker = executor.run(async move {
+            let mut connection = Box::pin(sender.connect());
+            let waker = poll_fn(|cx| {
+                assert!(connection.as_mut().poll(cx).is_pending());
+                Poll::Ready(cx.waker().clone())
+            })
+            .await;
+            drop(connection);
+            waker
+        });
+        drop(executor);
+        // The notifier is released off the executor thread, so the id outlives it.
+        std::thread::sleep(Duration::from_millis(100));
+
+        let executor = LocalExecutor::default();
+        executor.run(async move {
+            drop(receiver.connect().await);
+        });
+        drop(retained_waker);
     }
 }

--- a/glommio/src/channels/spsc_queue.rs
+++ b/glommio/src/channels/spsc_queue.rs
@@ -332,6 +332,14 @@ pub(crate) trait BufferHalf {
     fn connect(&self, id: usize);
     fn peer_id(&self) -> usize;
 
+    /// Marks the *other* half disconnected.
+    ///
+    /// For when the peer cannot be reached rather than has said goodbye: it
+    /// registered an executor id and that executor no longer exists, so
+    /// nothing will ever arrive from it and nothing sent to it can be
+    /// noticed. Indistinguishable, from this side, from a peer that hung up.
+    fn disconnect_peer(&self);
+
     /// Returns the total capacity of this queue
     ///
     /// This value represents the total capacity of the queue when it is full.
@@ -363,6 +371,11 @@ impl<T> BufferHalf for Producer<T> {
 
     fn peer_id(&self) -> usize {
         self.buffer.pcache.consumer_id.load(Ordering::Acquire)
+    }
+
+    fn disconnect_peer(&self) {
+        // We are the producer, so the peer is the consumer.
+        self.buffer.disconnect_consumer();
     }
 }
 
@@ -418,6 +431,11 @@ impl<T> BufferHalf for Consumer<T> {
 
     fn peer_id(&self) -> usize {
         self.buffer.ccache.producer_id.load(Ordering::Acquire)
+    }
+
+    fn disconnect_peer(&self) {
+        // We are the consumer, so the peer is the producer.
+        self.buffer.disconnect_producer();
     }
 }
 

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -194,15 +194,8 @@ impl TaskQueue {
     ///
     /// Stored in each task's header so its schedule function can find the
     /// queue without capturing a reference to it. See `schedule_runnable`.
-    pub(crate) fn index(&self) -> u32 {
-        // Panic rather than truncate. The header stores this narrowed, and a
-        // silent wrap would have a task scheduled onto a different queue with
-        // nothing to show for it.
-        self.stats
-            .index
-            .index()
-            .try_into()
-            .expect("task queue index outgrew u32")
+    pub(crate) fn index(&self) -> usize {
+        self.stats.index.index()
     }
 
     fn new<S>(
@@ -1120,7 +1113,7 @@ impl<T> PoolThreadHandles<T> {
 /// and did nothing when it failed to upgrade.
 pub(crate) fn schedule_runnable(runnable: multitask::Runnable) {
     let handle = TaskQueueHandle {
-        index: runnable.task_queue_index() as usize,
+        index: runnable.task_queue_index(),
     };
 
     #[cfg(any(not(nightly), not(feature = "native-tls")))]
@@ -1404,7 +1397,6 @@ impl LocalExecutor {
 
         let id = self.id;
         let ex = tq.borrow().ex.clone();
-        let id = id.try_into().expect("executor id outgrew u32");
         ex.spawn_and_run(id, tq, future)
     }
 
@@ -1449,7 +1441,6 @@ impl LocalExecutor {
         let id = self.id;
 
         // can't run right away, because we need to cross into a different task queue
-        let id = id.try_into().expect("executor id outgrew u32");
         Ok(ex.spawn_and_schedule(id, tq, future))
     }
 

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -190,6 +190,21 @@ impl PartialEq for TaskQueue {
 impl Eq for TaskQueue {}
 
 impl TaskQueue {
+    /// The index this queue is registered under in the executor's queue map.
+    ///
+    /// Stored in each task's header so its schedule function can find the
+    /// queue without capturing a reference to it. See `schedule_runnable`.
+    pub(crate) fn index(&self) -> u32 {
+        // Panic rather than truncate. The header stores this narrowed, and a
+        // silent wrap would have a task scheduled onto a different queue with
+        // nothing to show for it.
+        self.stats
+            .index
+            .index()
+            .try_into()
+            .expect("task queue index outgrew u32")
+    }
+
     fn new<S>(
         index: TaskQueueHandle,
         name: S,
@@ -1087,6 +1102,52 @@ impl<T> PoolThreadHandles<T> {
     }
 }
 
+/// Pushes a woken task back onto its task queue and activates that queue.
+///
+/// The task carries the index of its queue in its header rather than a
+/// reference to it, so this resolves the queue from the executor running on
+/// this thread. That is sound because every caller of a task's schedule
+/// function -- `do_wake`, `drop_waker` and `run` in `task::raw` -- first checks
+/// that the current thread owns the task, and routes to the notifier otherwise.
+///
+/// Keeping the queue out of the schedule closure is what lets that closure be
+/// zero-sized, which lets `RawTask::schedule` skip the waker clone/drop guard
+/// it would otherwise need. See `Header::task_queue_index`.
+///
+/// A missing queue means the queue was destroyed, or the executor is shutting
+/// down; in both cases the runnable is dropped, which cancels the task. This
+/// matches the previous behaviour, where the closure held a `Weak` to the queue
+/// and did nothing when it failed to upgrade.
+pub(crate) fn schedule_runnable(runnable: multitask::Runnable) {
+    let handle = TaskQueueHandle {
+        index: runnable.task_queue_index() as usize,
+    };
+
+    #[cfg(any(not(nightly), not(feature = "native-tls")))]
+    {
+        if LOCAL_EX.is_set() {
+            LOCAL_EX.with(|local_ex| {
+                if let Some(tq) = local_ex.get_queue(&handle) {
+                    tq.borrow().ex.push_task(runnable);
+                    maybe_activate(tq);
+                }
+            });
+        }
+    }
+
+    #[cfg(all(nightly, feature = "native-tls"))]
+    {
+        // SAFETY: `LOCAL_EX` is a thread-local raw pointer to the executor
+        // running on this thread; it is null when none is running.
+        if let Some(local_ex) = unsafe { LOCAL_EX.as_ref() } {
+            if let Some(tq) = local_ex.get_queue(&handle) {
+                tq.borrow().ex.push_task(runnable);
+                maybe_activate(tq);
+            }
+        }
+    }
+}
+
 pub(crate) fn maybe_activate(tq: Rc<RefCell<TaskQueue>>) {
     #[cfg(any(not(nightly), not(feature = "native-tls")))]
     {
@@ -1343,6 +1404,7 @@ impl LocalExecutor {
 
         let id = self.id;
         let ex = tq.borrow().ex.clone();
+        let id = id.try_into().expect("executor id outgrew u32");
         ex.spawn_and_run(id, tq, future)
     }
 
@@ -1387,6 +1449,7 @@ impl LocalExecutor {
         let id = self.id;
 
         // can't run right away, because we need to cross into a different task queue
+        let id = id.try_into().expect("executor id outgrew u32");
         Ok(ex.spawn_and_schedule(id, tq, future))
     }
 

--- a/glommio/src/executor/multitask.rs
+++ b/glommio/src/executor/multitask.rs
@@ -9,7 +9,7 @@
 #![warn(missing_docs, missing_debug_implementations)]
 
 use crate::{
-    executor::{maybe_activate, TaskQueue},
+    executor::TaskQueue,
     task::{task_impl, JoinHandle},
     Latency,
 };
@@ -111,6 +111,22 @@ impl LocalQueue {
     }
 }
 
+/// Compile-time proof that the schedule closure captures nothing.
+///
+/// `RawTask::schedule` only skips its waker clone/drop guard -- two atomic
+/// read-modify-writes on every wake -- when the schedule function is
+/// zero-sized. Capturing anything at all silently gives that back, costing
+/// roughly a third of a task switch with no test failing. Fail the build
+/// instead.
+fn assert_zero_sized<T>(_: &T) {
+    const {
+        assert!(
+            std::mem::size_of::<T>() == 0,
+            "the schedule closure must capture nothing: see Header::task_queue_index"
+        )
+    }
+}
+
 /// A single-threaded executor.
 #[derive(Debug)]
 pub(crate) struct LocalExecutor {
@@ -136,37 +152,44 @@ impl LocalExecutor {
     /// Spawns a thread-local future onto this executor.
     fn spawn<T>(
         &self,
-        executor_id: usize,
+        executor_id: u32,
         tq: Rc<RefCell<TaskQueue>>,
         future: impl Future<Output = T>,
     ) -> (Runnable, JoinHandle<T>) {
-        let latency_matters = match tq.borrow().io_requirements.latency_req {
-            Latency::Matters(_) => true,
-            Latency::NotImportant => false,
+        let (latency_matters, task_queue_index) = {
+            let tq = tq.borrow();
+            let latency_matters = match tq.io_requirements.latency_req {
+                Latency::Matters(_) => true,
+                Latency::NotImportant => false,
+            };
+            (latency_matters, tq.index())
         };
-        let tq = Rc::downgrade(&tq);
 
         // The function that schedules a runnable task when it gets woken up.
-        let schedule = move |runnable: Runnable| {
-            let tq = tq.upgrade();
-
-            if let Some(tq) = tq {
-                {
-                    let queue = tq.borrow();
-                    queue.ex.local_queue.push(runnable);
-                }
-                maybe_activate(tq);
-            }
-        };
+        //
+        // This closure captures nothing, so it is zero-sized. That matters:
+        // `RawTask::schedule` guards a non-zero-sized schedule function by
+        // cloning and dropping a waker around the call, which costs two atomic
+        // read-modify-writes on every wake. Capturing so much as a `Weak` to
+        // the task queue here would reintroduce them. The queue is instead
+        // found from the index in the task header -- see `schedule_runnable`.
+        let schedule = |runnable: Runnable| crate::executor::schedule_runnable(runnable);
+        assert_zero_sized(&schedule);
 
         // Create a task, push it into the queue by scheduling it, and return its `Task`
         // handle.
-        task_impl::spawn_local(executor_id, future, schedule, latency_matters)
+        task_impl::spawn_local(
+            executor_id,
+            task_queue_index,
+            future,
+            schedule,
+            latency_matters,
+        )
     }
 
     pub(crate) fn spawn_and_run<T>(
         &self,
-        executor_id: usize,
+        executor_id: u32,
         tq: Rc<RefCell<TaskQueue>>,
         future: impl Future<Output = T>,
     ) -> Task<T> {
@@ -177,13 +200,18 @@ impl LocalExecutor {
 
     pub(crate) fn spawn_and_schedule<T>(
         &self,
-        executor_id: usize,
+        executor_id: u32,
         tq: Rc<RefCell<TaskQueue>>,
         future: impl Future<Output = T>,
     ) -> Task<T> {
         let (runnable, handle) = self.spawn(executor_id, tq, future);
         runnable.schedule();
         Task(Some(handle))
+    }
+
+    /// Pushes a woken task onto this queue's run list.
+    pub(crate) fn push_task(&self, runnable: Runnable) {
+        self.local_queue.push(runnable);
     }
 
     /// Gets one task from the queue, if one exists.

--- a/glommio/src/executor/multitask.rs
+++ b/glommio/src/executor/multitask.rs
@@ -152,7 +152,7 @@ impl LocalExecutor {
     /// Spawns a thread-local future onto this executor.
     fn spawn<T>(
         &self,
-        executor_id: u32,
+        executor_id: usize,
         tq: Rc<RefCell<TaskQueue>>,
         future: impl Future<Output = T>,
     ) -> (Runnable, JoinHandle<T>) {
@@ -189,7 +189,7 @@ impl LocalExecutor {
 
     pub(crate) fn spawn_and_run<T>(
         &self,
-        executor_id: u32,
+        executor_id: usize,
         tq: Rc<RefCell<TaskQueue>>,
         future: impl Future<Output = T>,
     ) -> Task<T> {
@@ -200,7 +200,7 @@ impl LocalExecutor {
 
     pub(crate) fn spawn_and_schedule<T>(
         &self,
-        executor_id: u32,
+        executor_id: usize,
         tq: Rc<RefCell<TaskQueue>>,
         future: impl Future<Output = T>,
     ) -> Task<T> {

--- a/glommio/src/task/debugging.rs
+++ b/glommio/src/task/debugging.rs
@@ -126,7 +126,7 @@ impl TaskDebugger {
             }
 
             let header = unsafe { &*(ptr as *const Header) };
-            if Some(header.executor_id as usize) != executor_id() && header.debugging.get() {
+            if Some(header.executor_id) != executor_id() && header.debugging.get() {
                 dbg.context.push(ctx);
                 dbg.debug_foreign_task(ptr);
                 return true;

--- a/glommio/src/task/debugging.rs
+++ b/glommio/src/task/debugging.rs
@@ -126,7 +126,7 @@ impl TaskDebugger {
             }
 
             let header = unsafe { &*(ptr as *const Header) };
-            if Some(header.notifier.id()) != executor_id() && header.debugging.get() {
+            if Some(header.executor_id as usize) != executor_id() && header.debugging.get() {
                 dbg.context.push(ctx);
                 dbg.debug_foreign_task(ptr);
                 return true;

--- a/glommio/src/task/header.rs
+++ b/glommio/src/task/header.rs
@@ -6,15 +6,9 @@
 use core::{fmt, task::Waker};
 #[cfg(feature = "debugging")]
 use std::cell::Cell;
-use std::sync::{
-    atomic::{AtomicI32, Ordering},
-    Arc,
-};
+use std::sync::atomic::{AtomicI32, Ordering};
 
-use crate::{
-    sys::SleepNotifier,
-    task::{raw::TaskVTable, state::*, utils::abort_on_panic},
-};
+use crate::task::{raw::TaskVTable, state::*, utils::abort_on_panic};
 
 pub(crate) type RefCount = i32;
 pub(crate) type AtomicRefCount = AtomicI32;
@@ -24,8 +18,29 @@ pub(crate) type AtomicRefCount = AtomicI32;
 /// This header is stored right at the beginning of every heap-allocated task.
 pub(crate) struct Header {
     /// ID of the executor to which task belongs to or in other words by which
-    /// task was spawned by
-    pub(crate) notifier: Arc<SleepNotifier>,
+    /// task was spawned by.
+    ///
+    /// Deliberately an id rather than an `Arc<SleepNotifier>`. Holding the
+    /// notifier here would mean resolving it from the global registry on every
+    /// spawn, which serialises all executors on a single lock, and would keep
+    /// the executor's eventfd alive for as long as any task outlives it. The
+    /// notifier is instead resolved from the id on the foreign-wake path, which
+    /// is rare. See `RawTask::notifier`.
+    pub(crate) executor_id: u32,
+
+    /// Index of the task queue this task belongs to.
+    ///
+    /// As with `executor_id`, this is an index rather than an
+    /// `Rc<RefCell<TaskQueue>>` or a `Weak` to one. Capturing the queue in the
+    /// schedule closure made that closure non-zero-sized, which in turn forced
+    /// `RawTask::schedule` to clone and drop a waker as a lifetime guard on
+    /// every single wake -- two atomic read-modify-writes per task switch, for
+    /// eight bytes of capture. Resolving the queue from this index on the
+    /// owning thread keeps the closure zero-sized and skips the guard entirely.
+    ///
+    /// A `u32` rather than a `usize` deliberately, as with `executor_id`:
+    /// together they keep `Header` at 40 bytes.
+    pub(crate) task_queue_index: u32,
 
     /// Current state of the task.
     pub(crate) state: u8,
@@ -112,7 +127,7 @@ impl Header {
 
         format!(
             "thread:{}|{:>9}|{:>7}|{:>9}|{:>6}|{:>6}|refs:{}",
-            self.notifier.id(),
+            self.executor_id,
             test!(SCHEDULED),
             test!(RUNNING),
             test!(COMPLETED),
@@ -134,7 +149,7 @@ impl fmt::Debug for Header {
                 "current_thread_id",
                 &crate::executor::executor_id().unwrap_or(usize::MAX),
             )
-            .field("thread_id", &self.notifier.id())
+            .field("thread_id", &self.executor_id)
             .field("scheduled", &(state & SCHEDULED != 0))
             .field("running", &(state & RUNNING != 0))
             .field("completed", &(state & COMPLETED != 0))

--- a/glommio/src/task/header.rs
+++ b/glommio/src/task/header.rs
@@ -26,7 +26,7 @@ pub(crate) struct Header {
     /// the executor's eventfd alive for as long as any task outlives it. The
     /// notifier is instead resolved from the id on the foreign-wake path, which
     /// is rare. See `RawTask::notifier`.
-    pub(crate) executor_id: u32,
+    pub(crate) executor_id: usize,
 
     /// Index of the task queue this task belongs to.
     ///
@@ -38,9 +38,7 @@ pub(crate) struct Header {
     /// eight bytes of capture. Resolving the queue from this index on the
     /// owning thread keeps the closure zero-sized and skips the guard entirely.
     ///
-    /// A `u32` rather than a `usize` deliberately, as with `executor_id`:
-    /// together they keep `Header` at 40 bytes.
-    pub(crate) task_queue_index: u32,
+    pub(crate) task_queue_index: usize,
 
     /// Current state of the task.
     pub(crate) state: u8,

--- a/glommio/src/task/lifecycle_tests.rs
+++ b/glommio/src/task/lifecycle_tests.rs
@@ -3,11 +3,14 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
-//! Task lifecycle tests that run under Miri.
+//! Task lifecycle tests, which run under the ordinary test runner and also
+//! under Miri.
 //!
 //! Every test in `tests.rs` builds a `LocalExecutor`, which means io_uring,
-//! which Miri cannot execute — so the most `unsafe`-dense code in the crate,
-//! `task::raw`, has had no undefined-behaviour coverage at all.
+//! which Miri cannot execute, so the most `unsafe`-dense code in the crate,
+//! `task::raw`, had no undefined-behaviour coverage at all. These need no
+//! reactor, which is what lets Miri run them; it is also why they cost nothing
+//! to run normally, and they do, on every `cargo test`.
 //!
 //! These drive the task machinery directly instead: allocate, run, schedule,
 //! cancel and drop, with a schedule function that just collects runnables.
@@ -15,11 +18,49 @@
 //! counting, the state transitions, and the allocation and teardown paths,
 //! which is where a use-after-free would live.
 //!
-//! Run with `make miri-core`.
+//! Run under Miri with
+//! `cargo +nightly miri test -p glommio --lib task::`, and under the normal
+//! test runner alongside everything else.
+
+/// Test-only override for the owning-executor identity, read by
+/// `raw::RawTask::thread_id` and set by nothing but the tests below.
+///
+/// `do_wake`, `drop_waker` and `run` all branch on whether the current thread
+/// owns the task, and with no executor installed that check always says "not
+/// mine" and sends everything down the foreign path. That makes the local
+/// teardown path, the reference counting and deallocation and the most
+/// `unsafe`-dense code in the crate, untestable without a reactor.
+#[cfg(test)]
+pub(crate) mod test_executor_id {
+    use std::cell::Cell;
+
+    thread_local! {
+        static ID: Cell<Option<usize>> = const { Cell::new(None) };
+    }
+
+    pub(crate) fn get() -> Option<usize> {
+        ID.with(Cell::get)
+    }
+
+    /// Sets the override for the current thread, restoring it on drop.
+    pub(crate) fn scoped(id: usize) -> Guard {
+        let previous = ID.with(|c| c.replace(Some(id)));
+        Guard(previous)
+    }
+
+    pub(crate) struct Guard(Option<usize>);
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            ID.with(|c| c.set(self.0));
+        }
+    }
+}
 
 #[cfg(test)]
 mod test {
-    use crate::task::{raw::test_executor_id, task_impl, task_impl::Task, JoinHandle};
+    use super::test_executor_id;
+    use crate::task::{task_impl, task_impl::Task, JoinHandle};
     use std::{
         cell::RefCell,
         future::Future,

--- a/glommio/src/task/lifecycle_tests.rs
+++ b/glommio/src/task/lifecycle_tests.rs
@@ -1,0 +1,233 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the MIT/Apache-2.0 License, at your convenience
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//
+//! Task lifecycle tests that run under Miri.
+//!
+//! Every test in `tests.rs` builds a `LocalExecutor`, which means io_uring,
+//! which Miri cannot execute — so the most `unsafe`-dense code in the crate,
+//! `task::raw`, has had no undefined-behaviour coverage at all.
+//!
+//! These drive the task machinery directly instead: allocate, run, schedule,
+//! cancel and drop, with a schedule function that just collects runnables.
+//! No reactor, no rings, no syscalls. That is enough to exercise the reference
+//! counting, the state transitions, and the allocation and teardown paths,
+//! which is where a use-after-free would live.
+//!
+//! Run with `make miri-core`.
+
+#[cfg(test)]
+mod test {
+    use crate::task::{raw::test_executor_id, task_impl, task_impl::Task, JoinHandle};
+    use std::{
+        cell::RefCell,
+        future::Future,
+        pin::Pin,
+        rc::Rc,
+        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+    };
+
+    const EXECUTOR_ID: u32 = 0;
+    const QUEUE_INDEX: u32 = 0;
+
+    /// A waker that does nothing, for polling a `JoinHandle` whose task has
+    /// already been run to completion.
+    fn noop_waker() -> Waker {
+        fn clone(_: *const ()) -> RawWaker {
+            RawWaker::new(std::ptr::null(), &VTABLE)
+        }
+        fn noop(_: *const ()) {}
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+        // SAFETY: every function in the vtable is a no-op and ignores its data
+        // pointer, so a null pointer is never dereferenced.
+        unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
+    }
+
+    fn poll_once<R>(handle: &mut JoinHandle<R>) -> Poll<Option<R>> {
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        Pin::new(handle).poll(&mut cx)
+    }
+
+    /// Collects rescheduled runnables so a test can run them by hand.
+    type Collected = Rc<RefCell<Vec<Task>>>;
+
+    /// Claims `EXECUTOR_ID` for this thread so the task's drop and wake paths
+    /// take the owning-thread branch. Must be held for as long as any task from
+    /// `spawn_capturing` is alive.
+    fn own_tasks() -> test_executor_id::Guard {
+        test_executor_id::scoped(EXECUTOR_ID as usize)
+    }
+
+    /// Spawn with a schedule closure that captures, so `RawTask::schedule`
+    /// takes its non-zero-sized path and clones a waker as a lifetime guard.
+    ///
+    /// The returned `Task` carries no reference yet: `run_right_away` and
+    /// `schedule` are the two entry points that give it one, exactly as
+    /// `spawn_and_run` and `spawn_and_schedule` do in the executor. Calling
+    /// `run` or dropping it directly would underflow the count.
+    fn spawn_capturing<F, R>(future: F, sink: Collected) -> (Task, JoinHandle<R>)
+    where
+        F: Future<Output = R>,
+        R: 'static,
+    {
+        task_impl::spawn_local(
+            EXECUTOR_ID,
+            QUEUE_INDEX,
+            future,
+            move |runnable: Task| sink.borrow_mut().push(runnable),
+            false,
+        )
+    }
+
+    #[test]
+    fn run_to_completion_yields_output() {
+        let _owned = own_tasks();
+        let sink: Collected = Default::default();
+        let (runnable, mut handle) = spawn_capturing(async { 42u32 }, sink.clone());
+
+        runnable.run_right_away();
+        assert!(
+            sink.borrow().is_empty(),
+            "a ready task should not reschedule"
+        );
+        assert_eq!(poll_once(&mut handle), Poll::Ready(Some(42)));
+    }
+
+    #[test]
+    fn dropping_the_runnable_cancels() {
+        let _owned = own_tasks();
+        let sink: Collected = Default::default();
+        let (runnable, mut handle) = spawn_capturing(async { 7u32 }, sink.clone());
+
+        // A runnable reaches a droppable place by being scheduled; dropping it
+        // there instead of running it cancels the task and drops its future.
+        // That is what the executor does when the task queue has gone away.
+        runnable.schedule();
+        drop(sink.borrow_mut().pop().expect("scheduled"));
+        assert_eq!(poll_once(&mut handle), Poll::Ready(None));
+    }
+
+    #[test]
+    fn dropping_the_handle_leaves_the_task_runnable() {
+        let _owned = own_tasks();
+        let sink: Collected = Default::default();
+        let (runnable, handle) = spawn_capturing(async { 1u32 }, sink.clone());
+
+        // Detaching: the task must still be safe to run and must tear itself
+        // down afterwards, with no handle left to collect the output.
+        drop(handle);
+        runnable.run_right_away();
+        assert!(sink.borrow().is_empty());
+    }
+
+    #[test]
+    fn dropping_both_without_running_frees_the_task() {
+        let _owned = own_tasks();
+        let sink: Collected = Default::default();
+        let (runnable, handle) = spawn_capturing(async { 1u32 }, sink.clone());
+        drop(handle);
+        runnable.schedule();
+        drop(sink.borrow_mut().pop().expect("scheduled"));
+        assert!(sink.borrow().is_empty());
+    }
+
+    #[test]
+    fn scheduling_hands_the_runnable_to_the_schedule_function() {
+        let _owned = own_tasks();
+        let sink: Collected = Default::default();
+        let (runnable, mut handle) = spawn_capturing(async { 9u32 }, sink.clone());
+
+        // `schedule` takes a reference, passes it to the schedule function, and
+        // relies on a guard to keep the closure's captured state alive if the
+        // task is freed during the call.
+        runnable.schedule();
+        assert_eq!(sink.borrow().len(), 1);
+
+        let rescheduled = sink.borrow_mut().pop().unwrap();
+        rescheduled.run();
+        assert_eq!(poll_once(&mut handle), Poll::Ready(Some(9)));
+    }
+
+    #[test]
+    fn a_task_that_yields_is_rescheduled_and_completes() {
+        struct YieldOnce(bool);
+        impl Future for YieldOnce {
+            type Output = u32;
+            fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<u32> {
+                if self.0 {
+                    Poll::Ready(5)
+                } else {
+                    self.0 = true;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+        }
+
+        let _owned = own_tasks();
+        let sink: Collected = Default::default();
+        let (runnable, mut handle) = spawn_capturing(YieldOnce(false), sink.clone());
+
+        // The first run leaves the task pending. Waking from inside the poll
+        // marks it scheduled, and `run` hands it back through the schedule
+        // function on the way out.
+        runnable.run_right_away();
+        let rescheduled = sink.borrow_mut().pop().expect("task should reschedule");
+        rescheduled.run();
+        assert_eq!(poll_once(&mut handle), Poll::Ready(Some(5)));
+    }
+
+    #[test]
+    fn a_larger_future_is_boxed_and_still_torn_down() {
+        // `spawn_local` boxes futures of 2KB or more, taking a different
+        // allocation path that has to free correctly too.
+        let _owned = own_tasks();
+        let sink: Collected = Default::default();
+        let buf = [7u8; 4096];
+        let big = async move { buf[0] as u32 };
+        assert!(std::mem::size_of_val(&big) >= 2048);
+
+        let (runnable, mut handle) = spawn_capturing(big, sink.clone());
+        runnable.run_right_away();
+        assert_eq!(poll_once(&mut handle), Poll::Ready(Some(7)));
+    }
+
+    #[test]
+    fn output_is_dropped_when_the_handle_goes_away_first() {
+        // The task completes with an output nobody collects; closing the task
+        // has to drop that output rather than leak it.
+        let dropped = Rc::new(RefCell::new(false));
+        struct NotifyOnDrop(Rc<RefCell<bool>>);
+        impl Drop for NotifyOnDrop {
+            fn drop(&mut self) {
+                *self.0.borrow_mut() = true;
+            }
+        }
+
+        let _owned = own_tasks();
+        let sink: Collected = Default::default();
+        let flag = dropped.clone();
+        let (runnable, handle) = spawn_capturing(async move { NotifyOnDrop(flag) }, sink.clone());
+
+        runnable.run_right_away();
+        assert!(!*dropped.borrow(), "output held by the handle");
+        drop(handle);
+        assert!(*dropped.borrow(), "output dropped with the handle");
+    }
+
+    #[test]
+    fn many_tasks_allocate_and_free() {
+        // Repetition, so a refcount that is off by one shows up as a leak or a
+        // double free rather than passing by luck.
+        let _owned = own_tasks();
+        let sink: Collected = Default::default();
+        for i in 0..64u32 {
+            let (runnable, mut handle) = spawn_capturing(async move { i }, sink.clone());
+            runnable.run_right_away();
+            assert_eq!(poll_once(&mut handle), Poll::Ready(Some(i)));
+        }
+        assert!(sink.borrow().is_empty());
+    }
+}

--- a/glommio/src/task/lifecycle_tests.rs
+++ b/glommio/src/task/lifecycle_tests.rs
@@ -28,8 +28,8 @@ mod test {
         task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
     };
 
-    const EXECUTOR_ID: u32 = 0;
-    const QUEUE_INDEX: u32 = 0;
+    const EXECUTOR_ID: usize = 0;
+    const QUEUE_INDEX: usize = 0;
 
     /// A waker that does nothing, for polling a `JoinHandle` whose task has
     /// already been run to completion.
@@ -57,7 +57,7 @@ mod test {
     /// take the owning-thread branch. Must be held for as long as any task from
     /// `spawn_capturing` is alive.
     fn own_tasks() -> test_executor_id::Guard {
-        test_executor_id::scoped(EXECUTOR_ID as usize)
+        test_executor_id::scoped(EXECUTOR_ID)
     }
 
     /// Spawn with a schedule closure that captures, so `RawTask::schedule`

--- a/glommio/src/task/mod.rs
+++ b/glommio/src/task/mod.rs
@@ -52,6 +52,7 @@
 pub mod debugging;
 pub(crate) mod header;
 pub(crate) mod join_handle;
+mod lifecycle_tests;
 pub(crate) mod raw;
 pub(crate) mod state;
 pub(crate) mod task_impl;

--- a/glommio/src/task/raw.rs
+++ b/glommio/src/task/raw.rs
@@ -27,41 +27,6 @@ use crate::{
     },
 };
 
-/// Test-only override for the owning-executor identity.
-///
-/// `do_wake`, `drop_waker` and `run` all branch on whether the current thread
-/// owns the task, and with no executor installed that check always says "not
-/// mine" and sends everything down the foreign path. That makes the local
-/// teardown path — the reference counting and deallocation, the most
-/// `unsafe`-dense code here — untestable without a reactor. See
-/// `task::lifecycle_tests`.
-#[cfg(test)]
-pub(crate) mod test_executor_id {
-    use std::cell::Cell;
-
-    thread_local! {
-        static ID: Cell<Option<usize>> = const { Cell::new(None) };
-    }
-
-    pub(crate) fn get() -> Option<usize> {
-        ID.with(Cell::get)
-    }
-
-    /// Sets the override for the current thread, restoring it on drop.
-    pub(crate) fn scoped(id: usize) -> Guard {
-        let previous = ID.with(|c| c.replace(Some(id)));
-        Guard(previous)
-    }
-
-    pub(crate) struct Guard(Option<usize>);
-
-    impl Drop for Guard {
-        fn drop(&mut self) {
-            ID.with(|c| c.set(self.0));
-        }
-    }
-}
-
 /// The vtable for a task.
 pub(crate) struct TaskVTable {
     /// Schedules the task.
@@ -212,11 +177,12 @@ where
     }
 
     fn thread_id() -> Option<usize> {
-        // The lifecycle tests need to take the owning-thread path without a
-        // `LocalExecutor`, which would pull in io_uring and so cannot run under
-        // Miri. Unset outside those tests, so behaviour is unchanged.
+        // The lifecycle tests take the owning-thread path without a
+        // `LocalExecutor`, which they cannot build: it would pull in io_uring,
+        // which needs a reactor and which Miri cannot execute either. Unset
+        // outside those tests, so behaviour is unchanged.
         #[cfg(test)]
-        if let Some(id) = test_executor_id::get() {
+        if let Some(id) = crate::task::lifecycle_tests::test_executor_id::get() {
             return Some(id);
         }
         crate::executor::executor_id()

--- a/glommio/src/task/raw.rs
+++ b/glommio/src/task/raw.rs
@@ -27,6 +27,41 @@ use crate::{
     },
 };
 
+/// Test-only override for the owning-executor identity.
+///
+/// `do_wake`, `drop_waker` and `run` all branch on whether the current thread
+/// owns the task, and with no executor installed that check always says "not
+/// mine" and sends everything down the foreign path. That makes the local
+/// teardown path — the reference counting and deallocation, the most
+/// `unsafe`-dense code here — untestable without a reactor. See
+/// `task::lifecycle_tests`.
+#[cfg(test)]
+pub(crate) mod test_executor_id {
+    use std::cell::Cell;
+
+    thread_local! {
+        static ID: Cell<Option<usize>> = const { Cell::new(None) };
+    }
+
+    pub(crate) fn get() -> Option<usize> {
+        ID.with(Cell::get)
+    }
+
+    /// Sets the override for the current thread, restoring it on drop.
+    pub(crate) fn scoped(id: usize) -> Guard {
+        let previous = ID.with(|c| c.replace(Some(id)));
+        Guard(previous)
+    }
+
+    pub(crate) struct Guard(Option<usize>);
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            ID.with(|c| c.set(self.0));
+        }
+    }
+}
+
 /// The vtable for a task.
 pub(crate) struct TaskVTable {
     /// Schedules the task.
@@ -111,7 +146,8 @@ where
     pub(crate) fn allocate(
         future: F,
         schedule: S,
-        executor_id: usize,
+        executor_id: u32,
+        task_queue_index: u32,
         latency_matters: bool,
     ) -> NonNull<()> {
         // Compute the layout of the task for allocation. Abort if the computation
@@ -129,7 +165,8 @@ where
 
             // Write the header as the first field of the task.
             (raw.header as *mut Header).write(Header {
-                notifier: sys::get_sleep_notifier_for(executor_id).unwrap(),
+                executor_id,
+                task_queue_index,
                 state: SCHEDULED | HANDLE,
                 latency_matters,
                 references: AtomicRefCount::new(0),
@@ -162,14 +199,26 @@ where
     }
 
     unsafe fn my_id(&self) -> usize {
-        self.notifier().id()
+        (*self.header).executor_id as usize
     }
 
-    unsafe fn notifier(&self) -> &sys::SleepNotifier {
-        &(*self.header).notifier
+    /// Resolves the owning executor's notifier from the global registry.
+    ///
+    /// Only called on the foreign-wake path, so the registry lock is taken once
+    /// per cross-thread wake rather than once per spawn. Returns `None` once the
+    /// owning executor is gone, in which case no one is left to poll the task.
+    unsafe fn notifier(&self) -> Option<std::sync::Arc<sys::SleepNotifier>> {
+        sys::get_sleep_notifier_for(self.my_id())
     }
 
     fn thread_id() -> Option<usize> {
+        // The lifecycle tests need to take the owning-thread path without a
+        // `LocalExecutor`, which would pull in io_uring and so cannot run under
+        // Miri. Unset outside those tests, so behaviour is unchanged.
+        #[cfg(test)]
+        if let Some(id) = test_executor_id::get() {
+            return Some(id);
+        }
         crate::executor::executor_id()
     }
 
@@ -224,11 +273,14 @@ where
         let raw = Self::from_ptr(ptr);
         if Self::thread_id() != Some(raw.my_id()) {
             dbg_context!(ptr, "foreign", {
-                let notifier = raw.notifier();
-                notifier.queue_waker(
-                    Waker::from_raw(Self::clone_waker(ptr)),
-                    (*raw.header).latency_matters,
-                );
+                // If the owning executor is gone there is nothing left to wake
+                // into, so the notification is dropped.
+                if let Some(notifier) = raw.notifier() {
+                    notifier.queue_waker(
+                        Waker::from_raw(Self::clone_waker(ptr)),
+                        (*raw.header).latency_matters,
+                    );
+                }
             });
         } else {
             let state = (*raw.header).state;
@@ -304,11 +356,15 @@ where
                     // is dropped, schedule it once more to ensure the task
                     // will be destroyed
                     if Self::decrement_references(&*(raw.header as *mut Header)) == 0 {
-                        let notifier = raw.notifier();
-                        notifier.queue_waker(
-                            Waker::from_raw(Self::clone_waker(ptr)),
-                            (*raw.header).latency_matters,
-                        );
+                        // As in `do_wake`: if the owning executor is already
+                        // gone there is nobody left to run the destruction, and
+                        // queueing onto a dead notifier would only strand it.
+                        if let Some(notifier) = raw.notifier() {
+                            notifier.queue_waker(
+                                Waker::from_raw(Self::clone_waker(ptr)),
+                                (*raw.header).latency_matters,
+                            );
+                        }
                     }
                     return;
                 });

--- a/glommio/src/task/raw.rs
+++ b/glommio/src/task/raw.rs
@@ -146,8 +146,8 @@ where
     pub(crate) fn allocate(
         future: F,
         schedule: S,
-        executor_id: u32,
-        task_queue_index: u32,
+        executor_id: usize,
+        task_queue_index: usize,
         latency_matters: bool,
     ) -> NonNull<()> {
         // Compute the layout of the task for allocation. Abort if the computation
@@ -199,7 +199,7 @@ where
     }
 
     unsafe fn my_id(&self) -> usize {
-        (*self.header).executor_id as usize
+        (*self.header).executor_id
     }
 
     /// Resolves the owning executor's notifier from the global registry.

--- a/glommio/src/task/task_impl.rs
+++ b/glommio/src/task/task_impl.rs
@@ -30,8 +30,8 @@ use std::sync::atomic::Ordering;
 /// [`Task`]: struct.Task.html
 /// [`JoinHandle`]: struct.JoinHandle.html
 pub(crate) fn spawn_local<F, R, S>(
-    executor_id: u32,
-    task_queue_index: u32,
+    executor_id: usize,
+    task_queue_index: usize,
     future: F,
     schedule: S,
     latency_matters: bool,
@@ -102,7 +102,7 @@ impl Task {
     /// Used by the schedule function to find its queue without capturing a
     /// reference to it, which is what keeps that closure zero-sized. See
     /// `Header::task_queue_index`.
-    pub(crate) fn task_queue_index(&self) -> u32 {
+    pub(crate) fn task_queue_index(&self) -> usize {
         let header = self.raw_task.as_ptr() as *const Header;
         // SAFETY: `raw_task` points at a live task allocation for as long as
         // this `Task` reference exists, and the header is its first field.

--- a/glommio/src/task/task_impl.rs
+++ b/glommio/src/task/task_impl.rs
@@ -30,7 +30,8 @@ use std::sync::atomic::Ordering;
 /// [`Task`]: struct.Task.html
 /// [`JoinHandle`]: struct.JoinHandle.html
 pub(crate) fn spawn_local<F, R, S>(
-    executor_id: usize,
+    executor_id: u32,
+    task_queue_index: u32,
     future: F,
     schedule: S,
     latency_matters: bool,
@@ -42,9 +43,21 @@ where
     // Allocate large futures on the heap.
     let raw_task = if mem::size_of::<F>() >= 2048 {
         let future = alloc::boxed::Box::pin(future);
-        RawTask::<_, R, S>::allocate(future, schedule, executor_id, latency_matters)
+        RawTask::<_, R, S>::allocate(
+            future,
+            schedule,
+            executor_id,
+            task_queue_index,
+            latency_matters,
+        )
     } else {
-        RawTask::<_, R, S>::allocate(future, schedule, executor_id, latency_matters)
+        RawTask::<_, R, S>::allocate(
+            future,
+            schedule,
+            executor_id,
+            task_queue_index,
+            latency_matters,
+        )
     };
 
     let task = Task { raw_task };
@@ -84,6 +97,18 @@ pub struct Task {
 }
 
 impl Task {
+    /// Returns the index of the task queue this task belongs to.
+    ///
+    /// Used by the schedule function to find its queue without capturing a
+    /// reference to it, which is what keeps that closure zero-sized. See
+    /// `Header::task_queue_index`.
+    pub(crate) fn task_queue_index(&self) -> u32 {
+        let header = self.raw_task.as_ptr() as *const Header;
+        // SAFETY: `raw_task` points at a live task allocation for as long as
+        // this `Task` reference exists, and the header is its first field.
+        unsafe { (*header).task_queue_index }
+    }
+
     /// Schedules the task.
     ///
     /// This is a convenience method that simply reschedules the task by passing


### PR DESCRIPTION
Independent of my other open PRs (#29, #30, #31), applies to `main` on its own.

A performance change. It is **not** the fix for #448: #40 is, and the two are
independent. The header there is never deallocated, so the `Arc<SleepNotifier>`
inside it never drops and the eventfd goes with it. This change stops tasks
holding the notifier at all, which relieves the fd symptom but leaves the memory
leak alone.

## The pattern

The task header held an `Arc<SleepNotifier>`, and the schedule closure held a `Weak<RefCell<TaskQueue>>`. Both are owned references to things the owning thread can simply look up, and both cost more than the lookup would.

### The notifier

Resolving it meant a **process-wide `RwLock` read on every spawn**, serialising every executor in the process:

| spawn, concurrent executors | before | after |
|---|---:|---:|
| 1 | 42.5 ns | 29.1 ns |
| 8 | 295.8 ns | 29.3 ns |
| 64 | **3760.1 ns** | **49.6 ns** |

Reproduce with the benchmarks in the first commit: `cargo run --release
--example spawn_scaling` and `--example spawn_bench`.

As a side effect tasks no longer keep their executor's eventfd alive, so a task whose destructor never runs cannot strand one. That is a symptom of #448 rather than its cause; see #40 for the cause.

### The task queue

Subtler. Capturing a `Weak` made the schedule closure non-zero-sized, and `RawTask::schedule` guards a non-zero-sized schedule function by cloning and dropping a waker around the call. **Eight bytes of capture cost two atomic read-modify-writes on every wake.** A counter confirmed the guard fires on 100% of schedule calls.

Carrying a `u32` queue index lets the closure be zero-sized and skips the guard entirely: **task switch 28.7 ns → 19.5 ns**.

## Why it's sound

Every caller of a task's schedule function, `do_wake`, `drop_waker` and `run`, first checks that the current thread owns the task and routes to the notifier otherwise. So a schedule function only ever executes with its own executor installed, which is what makes resolving from a thread-local safe.

The case I expected to break was `LocalExecutor::spawn` before `run()`, where no executor is installed. It can't: `thread_id()` returns `None` there, so `None != Some(my_id)` sends the wake down the foreign path and the notifier delivers it once `run()` starts.

## Header size

`executor_id` is a `u32` rather than a `usize` so that both indices land in padding the header was already paying for. **`Header` stays 40 bytes**, including the `AtomicI32` refcount:

```
awaiter 16 | vtable 8 | executor_id 4 | task_queue_index 4
references 4 | state 1 | latency_matters 1 | padding 2
```

## One guard rail

`assert_zero_sized` fails the build if anything is ever captured in that closure again. Without it, a future change would silently give back a third of a task switch with no test failing. Verified by injecting a capture.

## Testing

407 lib tests pass. `cargo fmt` clean. No clippy errors beyond the three already on `main` from `GlommioError::into_inner`.

Numbers are from a single machine (Threadripper PRO 9975WX), measured with the builds alternated back to back rather than compared across sessions, this box's baseline for unchanged code drifts enough between runs to swamp the effect otherwise.
