### PR TITLE
Fix rare test flake

### DIFF
--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -493,7 +493,7 @@ mod test {
     use std::{
         sync::{
             atomic::{AtomicUsize, Ordering},
-            Arc,
+            mpsc, Arc,
         },
         time::Duration,
     };
@@ -911,14 +911,17 @@ mod test {
     #[test]
     fn shared_drop_cascade_drop_executor_reverse() {
         let (sender, receiver) = new_bounded(100);
+        let (connected_tx, connected_rx) = mpsc::channel();
 
         let original = Arc::new(AtomicUsize::new(0));
         let send_count = original.clone();
         let drop_count = original.clone();
+        let sender_connected = connected_tx.clone();
 
         let ex1 = LocalExecutorBuilder::default()
             .spawn(move || async move {
                 let sender = sender.connect().await;
+                sender_connected.send(()).unwrap();
                 for x in 0..50 {
                     let val = WithDrop(send_count.clone(), x);
                     drop_count.fetch_add(1, Ordering::SeqCst);
@@ -930,6 +933,7 @@ mod test {
         let ex2 = LocalExecutorBuilder::default()
             .spawn(move || async move {
                 let receiver = receiver.connect().await;
+                connected_tx.send(()).unwrap();
                 for x in 0..50 {
                     let resp = receiver.recv().await.unwrap();
                     assert_eq!(x, resp.1);
@@ -937,6 +941,11 @@ mod test {
             })
             .unwrap();
 
+        // Both endpoints must be connected before destroying the sender's
+        // executor. Otherwise the receiver can observe its peer ID after the
+        // sender's reactor has already removed the corresponding notifier.
+        connected_rx.recv().unwrap();
+        connected_rx.recv().unwrap();
         drop(ex1);
         ex2.join().unwrap();
 


### PR DESCRIPTION
### What does this PR do?

Deflakes a rare test flake

### Motivation

Saw this false-positive test failure:
```
failures:
---- channels::shared_channel::test::shared_drop_cascade_drop_executor_reverse stdout ----
thread 'unnamed-67' (3258883) panicked at glommio/src/channels/shared_channel.rs:140:63:
called Option::unwrap() on a None value
thread 'channels::shared_channel::test::shared_drop_cascade_drop_executor_reverse' (3258791) panicked at glommio/src/channels/shared_channel.rs:944:20:
called Result::unwrap() on an Err value: Thread panicked { .. }
failures:
channels::shared_channel::test::shared_drop_cascade_drop_executor_reverse
```

### Related issues

N/A

### Additional Notes

Couldn't reproduce but Codex explained the issue. The fix seems sensible.

### Checklist

[X] I have added unit tests to the code I am submitting
[X] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
