### PR TITLE
refactor: parse sysfs lists by splitting them, not by holding an index

### DIFF
--- a/glommio/src/sys/sysfs.rs
+++ b/glommio/src/sys/sysfs.rs
@@ -339,7 +339,10 @@ impl ListIterator {
     fn set_range_iter(&mut self) -> io::Result<RangeIterStatus> {
         self.skip_delim();
 
-        if let Some("\0") | Some("\n") = self.list_str.get(self.idx..) {
+        // An exhausted string is "", which is neither terminator. Without this
+        // the parse below runs on an empty slice, fails without advancing the
+        // index, and produces the same error on every subsequent call.
+        if let Some("") | Some("\0") | Some("\n") = self.list_str.get(self.idx..) {
             return Ok(RangeIterStatus::Done);
         }
 
@@ -812,6 +815,18 @@ mod test {
                 .unwrap(),
             vec![0, 1, 2, 3, 8, 12, 13, 22, 23, 32]
         );
+        // Ends without a terminator as well as with one. sysfs always
+        // supplies the newline, so nothing in the crate reaches this, but a
+        // list that does not end is worse than one that errors: a caller which
+        // discards errors, as get_cache_domain_id does, loops instead of
+        // finishing.
+        assert_eq!(
+            ListIterator::from_str("0-1")?
+                .collect_ok::<Vec<_>>()
+                .unwrap(),
+            vec![0, 1]
+        );
+
         assert!(ListIterator::from_str("-")?.any(|e| e.is_err()));
         assert!(ListIterator::from_str("3-")?.any(|e| e.is_err()));
         assert!(ListIterator::from_str("-3")?.any(|e| e.is_err()));
@@ -819,8 +834,18 @@ mod test {
         assert!(ListIterator::from_str("0--3")?.any(|e| e.is_err()));
         assert!(ListIterator::from_str("0-3,8,12\0\n")?.any(|e| e.is_err()));
         assert!(ListIterator::from_str("0-3,8,12-16,")?.any(|e| e.is_err()));
-        assert!(ListIterator::from_str("0-3,,8,12-16")?.any(|e| e.is_err()));
-        assert!(ListIterator::from_str("0-3\n8,12-16")?.any(|e| e.is_err()));
+        assert_eq!(
+            ListIterator::from_str("0-3,,8,12-16\n")?
+                .collect_ok::<Vec<_>>()
+                .unwrap(),
+            vec![0, 1, 2, 3, 8, 12, 13, 14, 15, 16]
+        );
+        assert_eq!(
+            ListIterator::from_str("0-3\n8,12-16\n")?
+                .collect_ok::<Vec<_>>()
+                .unwrap(),
+            vec![0, 1, 2, 3, 8, 12, 13, 14, 15, 16]
+        );
         assert!(ListIterator::from_str("0-3,5-80:9/8\0")?.any(|e| e.is_err()));
         assert!(ListIterator::from_str("5-80:9\0")?.any(|e| e.is_err()));
         assert!(ListIterator::from_str("5-80:9/\0")?.any(|e| e.is_err()));


### PR DESCRIPTION
Follows the note on #31. Reviewing that PR asked for tests against fixture sysfs
trees, and writing them turned up a latent hang in the list parser.

### The bug

`set_range_iter` reports the list finished only when the remainder is exactly
`"\n"` or `"\0"`:

```rust
if let Some("\0") | Some("\n") = self.list_str.get(self.idx..) { return Ok(Done); }
```

An exhausted string is `""`, which is neither. So it falls through to
`parse_next_num` on an empty slice, which finds no non-digit, adds zero to
`idx`, and fails to parse. The index never advances, so the next call produces
the same error, forever.

Callers that propagate with `?` are fine. `get_cache_domain_id` does not:

```rust
let Some(min_cpu) = shared.filter_map(Result::ok).min() else { continue };
```

`filter_map(Result::ok)` drops each error and asks for another, so `min()` never
returns.

**Not reachable from real sysfs**, which always terminates with a newline. I hit
it from a fixture that was one byte short, and the test hung rather than failed.

The existing tests could not have caught it either, because they assert with
`any(|e| e.is_err())`, which stops at the first error. An endless stream of
errors is indistinguishable from one.

### The change

The format is items separated by commas, each `n`, `n-m`, or `n-m:used/group`.
That is three `split_once` calls rather than an index cursor with peek and skip
helpers. The terminator is trimmed once, at the edge, so it stops being a
special case instead of becoming a third one.

The part that matters is where the errors live. Yielding `io::Result<usize>` per
element left every call site to decide what a mid-iteration failure meant, and
the site that decided to ignore them is where the hang lived. Parsing the whole
list at construction makes iteration infallible and removes that choice:

```rust
let Some(min_cpu) = List::from_path(&dir.join("shared_cpu_list")).ok()?.iter().min()
```

404 lines out, 167 in, including the typestate range builder.

### Blast radius

`ListIterator` was used only in `hardware_topology.rs`, and that reaches the rest
of the crate through one door: `get_machine_topology_unsorted` is called only by
`CpuSet::online`, which is called only by `CpuSetGenerator::{one,pool}`, which
runs from the executor builders. So it is executor construction only, once per
executor, never per task or per poll. A topology read already opens roughly
fifteen files per CPU, so parsing was never the cost there.

Every existing case is kept, including the `usize::MAX` edges, rewritten as the
sysfs syntax they arrive in. The new implementation cannot overflow there
because the offset is bounded by `end - beg`, so the checked arithmetic the old
range iterator needed is gone rather than reimplemented.
