### PR TITLE
fix: stop setting MSG_ZEROCOPY on every socket send

### DIFF
--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -45,8 +45,6 @@ use buddy_alloc::buddy_alloc::{BuddyAlloc, BuddyAllocParam};
 use nix::sys::socket::{MsgFlags, SockFlag};
 use smallvec::SmallVec;
 
-const MSG_ZEROCOPY: i32 = 0x4000000;
-
 #[allow(dead_code)]
 #[derive(Debug)]
 enum UringOpDescriptor {
@@ -506,12 +504,12 @@ where
                     .offset(pos)
                     .build()
             }
-            UringOpDescriptor::SockSend(ptr, len, flags) => opcode::Send::new(fd, ptr, len as u32)
-                .flags(flags | MSG_ZEROCOPY)
-                .build(),
+            UringOpDescriptor::SockSend(ptr, len, flags) => {
+                opcode::Send::new(fd, ptr, len as u32).flags(flags).build()
+            }
             UringOpDescriptor::SockSendMsg(hdr, flags) => {
                 opcode::SendMsg::new(fd, hdr as *const libc::msghdr)
-                    .flags((flags | MSG_ZEROCOPY) as u32)
+                    .flags(flags as u32)
                     .build()
             }
             UringOpDescriptor::SockRecv(len, flags) => {


### PR DESCRIPTION
One file, 19 lines added and 6 removed, most of it a comment.

`MSG_ZEROCOPY` is set on every `Send` and `SendMsg`:

```rust
UringOpDescriptor::SockSend(ptr, len, flags) => opcode::Send::new(fd, ptr, len as u32)
    .flags(flags | MSG_ZEROCOPY)
```

Nothing in the crate sets `SO_ZEROCOPY` on the socket, and the kernel only takes
the zero-copy path when that option is set. So the flag does nothing today, and
has done nothing since it was written. Removing it changes no behaviour.

### Why it is worth removing rather than leaving

Inert is not the same as harmless. `AsRawFd` is public on `TcpStream` and
`UdpSocket`, so a caller can set `SO_ZEROCOPY` on the socket themselves. That
arms a send path which frees its buffer when the send CQE arrives, while the
kernel still holds those pages. With `MSG_ZEROCOPY` the send CQE means "queued",
not "done with your memory"; the release notification arrives on the socket's
error queue, which nothing here reads.

The buffer would then be returned and reused while the NIC is still reading it,
so freed memory goes on the wire. Reachable without writing any `unsafe`, by a
caller doing something the API invites: taking the fd and calling `setsockopt`.

A real zero-copy send is `IORING_OP_SEND_ZC`, where the notification is a second
CQE on the ring rather than an errqueue message, so the ownership handoff is
visible to the same code that submitted the send. The comment says that, so the
flag does not come back as an apparent optimisation.

Found while reconciling our fork against `main`. It is one of a handful of fixes
we had sitting locally that apply to upstream unchanged.
