### PR TITLE
fix: treat a peer whose executor is gone as disconnected

### DIFF
--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -134,7 +134,22 @@ impl<T: BufferHalf> Future for Connector<T> {
             }
             // usize::MAX (the disconnected) always has a placeholder notifier that never
             // returns its fd. So if the other side disconnected it will unblock us here
-            id => Poll::Ready(sys::get_sleep_notifier_for(id).unwrap()),
+            id => Poll::Ready(sys::get_sleep_notifier_for(id).unwrap_or_else(|| {
+                // The peer registered this id and then its executor went away.
+                // Those two are not ordered against each other: the executor
+                // drops its notifier on its own schedule, while the id stays in
+                // the buffer until the peer's half is dropped. So the surviving
+                // side can land here holding an id whose notifier is already
+                // gone, and unwrapping it panics.
+                //
+                // An executor that no longer exists cannot be woken and cannot
+                // send, which is what being disconnected means. Say so in the
+                // buffer as well, or this side goes on to wait forever for a
+                // peer that cannot arrive.
+                self.buffer.disconnect_peer();
+                sys::get_sleep_notifier_for(usize::MAX)
+                    .expect("the disconnected notifier is a static and always exists")
+            })),
         }
     }
 }
@@ -1001,5 +1016,62 @@ mod test {
 
         ex1.join().unwrap();
         ex2.join().unwrap();
+    }
+
+    #[test]
+    fn a_peer_whose_executor_is_gone_reads_as_disconnected() {
+        // The race this stands in for: a peer connects, registering its
+        // executor id in the buffer, and then that executor is destroyed. The
+        // id and the notifier are not dropped together, the executor drops its
+        // notifier on its own schedule while the id sits in the buffer until
+        // the peer's half is dropped, so the surviving side can look up an id
+        // whose notifier has already gone. It panics on the `unwrap`.
+        //
+        // The window cannot be raced for on this tree, because the state it
+        // needs does not occur here yet. `sleep_notifiers` holds `Weak`, so an
+        // id stops resolving only once the last `Arc<SleepNotifier>` is
+        // dropped, and today nothing drops: eight executors created and joined
+        // leave eight notifiers still resolvable, with no tasks spawned at all.
+        // That is #448, and while it holds, this panic is unreachable.
+        //
+        // It becomes reachable as soon as #448 is fixed. On a tree where the
+        // task header carries an executor id rather than an `Arc` to the
+        // notifier, the same eight executors leave none behind, and this
+        // panics roughly one full test run in five.
+        //
+        // So the test asks for the state directly. An id no executor ever
+        // registered resolves to `None` exactly as a released one will, and
+        // reverting either half of the fix still fails here.
+        const NEVER_REGISTERED: usize = usize::MAX - 4096;
+
+        crate::LocalExecutor::default().run(async {
+            let (sender, receiver) = new_bounded::<u32>(4);
+
+            // Stand in for the departed peer: its id is in the buffer, and
+            // there is no notifier behind it.
+            assert!(
+                sys::get_sleep_notifier_for(NEVER_REGISTERED).is_none(),
+                "this id must have no notifier, or the test proves nothing"
+            );
+            sender
+                .state
+                .as_ref()
+                .unwrap()
+                .buffer
+                .connect(NEVER_REGISTERED);
+
+            let receiver = receiver.connect().await;
+
+            assert!(
+                receiver.state.buffer.producer_disconnected(),
+                "a peer that cannot be woken has to read as disconnected, or \
+                 this side waits forever for something that cannot arrive"
+            );
+            assert_eq!(
+                receiver.recv().await,
+                None,
+                "reads must end rather than hang"
+            );
+        });
     }
 }

--- a/glommio/src/channels/spsc_queue.rs
+++ b/glommio/src/channels/spsc_queue.rs
@@ -332,6 +332,14 @@ pub(crate) trait BufferHalf {
     fn connect(&self, id: usize);
     fn peer_id(&self) -> usize;
 
+    /// Marks the *other* half disconnected.
+    ///
+    /// For when the peer cannot be reached rather than has said goodbye: it
+    /// registered an executor id and that executor no longer exists, so
+    /// nothing will ever arrive from it and nothing sent to it can be
+    /// noticed. Indistinguishable, from this side, from a peer that hung up.
+    fn disconnect_peer(&self);
+
     /// Returns the total capacity of this queue
     ///
     /// This value represents the total capacity of the queue when it is full.
@@ -363,6 +371,11 @@ impl<T> BufferHalf for Producer<T> {
 
     fn peer_id(&self) -> usize {
         self.buffer.pcache.consumer_id.load(Ordering::Acquire)
+    }
+
+    fn disconnect_peer(&self) {
+        // We are the producer, so the peer is the consumer.
+        self.buffer.disconnect_consumer();
     }
 }
 
@@ -418,6 +431,11 @@ impl<T> BufferHalf for Consumer<T> {
 
     fn peer_id(&self) -> usize {
         self.buffer.ccache.producer_id.load(Ordering::Acquire)
+    }
+
+    fn disconnect_peer(&self) {
+        // We are the consumer, so the peer is the producer.
+        self.buffer.disconnect_producer();
     }
 }
 


### PR DESCRIPTION
Two files, +80/-1, one of which is the regression test.

`Connector::poll` resolves the peer's executor id to its sleep notifier and
unwraps:

```rust
// usize::MAX (the disconnected) always has a placeholder notifier that never
// returns its fd. So if the other side disconnected it will unblock us here
id => Poll::Ready(sys::get_sleep_notifier_for(id).unwrap()),
```

The comment covers three cases: not connected yet, disconnected, or a live
executor. There is a fourth. The id and the notifier are not dropped together:
an executor drops its notifier on its own schedule, while its id stays in the
buffer until the peer's channel half is dropped. So the surviving side can hold
a real id whose notifier has already gone, `get_sleep_notifier_for` returns
`None`, and the unwrap panics.

### Both halves are needed

Returning the placeholder notifier stops the panic and leaves this side waiting
forever for a peer that cannot arrive, which trades a crash for a hang. So the
peer is also marked disconnected in the buffer. An executor that no longer
exists can neither be woken nor send, which is exactly what disconnected means.

### Testing it without racing

The window is timing, but the state it produces is not. An id that no executor
ever registered resolves to `None` from `get_sleep_notifier_for` exactly as a
dropped one does, so the test connects against one and gets the same path
deterministically.

Reverting either half fails it, which I checked rather than assumed:

- without the fix: panics at `shared_channel.rs:137`, the unwrap
- with the placeholder but without marking disconnected: fails on the
  disconnected assertion, and would hang in production

### Possibly relevant to #32

We see this on our fork as an intermittent failure at roughly one full-suite run
in five. While working on #32 I saw `shared_drop_gets_called` and `copy_shared`
fail once and could not reproduce it, and I guessed at fd exhaustion in a comment
there. This is a likelier explanation, since it is the same subsystem and the
same intermittency. I did not capture the panic message at the time, so I cannot
say for certain.
