### PR TITLE
perf: accept without toggling O_NONBLOCK on every call

### DIFF
--- a/glommio/src/net/mod.rs
+++ b/glommio/src/net/mod.rs
@@ -15,16 +15,21 @@ use std::{
 };
 
 fn yolo_accept(fd: BorrowedFd<'_>) -> Option<io::Result<RawFd>> {
-    let flags =
-        nix::fcntl::OFlag::from_bits(nix::fcntl::fcntl(fd, nix::fcntl::F_GETFL).unwrap()).unwrap();
-    nix::fcntl::fcntl(
-        fd,
-        nix::fcntl::F_SETFL(flags | nix::fcntl::OFlag::O_NONBLOCK),
-    )
-    .unwrap();
-    let r = sys::accept_syscall(fd.as_raw_fd());
-    nix::fcntl::fcntl(fd, nix::fcntl::F_SETFL(flags)).unwrap();
-    match r {
+    // Listeners are put in non-blocking mode when they are created, so this
+    // returns `EAGAIN` rather than blocking the executor when the backlog is
+    // empty. It used to flip the flag on and back around every call, which
+    // cost two extra `fcntl` syscalls per accepted connection, and three
+    // `unwrap`s on a path that runs per connection.
+    debug_assert!(
+        {
+            let flags = nix::fcntl::fcntl(fd, nix::fcntl::F_GETFL).unwrap();
+            nix::fcntl::OFlag::from_bits_truncate(flags).contains(nix::fcntl::OFlag::O_NONBLOCK)
+        },
+        "a listener reached accept in blocking mode: whoever built it skipped \
+         set_nonblocking, and this call would park the whole executor"
+    );
+
+    match sys::accept_syscall(fd.as_raw_fd()) {
         Ok(x) => Some(Ok(x)),
         Err(err) => match err.kind() {
             io::ErrorKind::WouldBlock => None,

--- a/glommio/src/net/mod.rs
+++ b/glommio/src/net/mod.rs
@@ -15,18 +15,14 @@ use std::{
 };
 
 fn yolo_accept(fd: BorrowedFd<'_>) -> Option<io::Result<RawFd>> {
-    // Listeners are put in non-blocking mode when they are created, so this
-    // returns `EAGAIN` rather than blocking the executor when the backlog is
-    // empty. It used to flip the flag on and back around every call, which
-    // cost two extra `fcntl` syscalls per accepted connection, and three
-    // `unwrap`s on a path that runs per connection.
+    // Listeners are non-blocking from construction, so this returns EAGAIN
+    // rather than parking the executor when the backlog is empty.
     debug_assert!(
         {
             let flags = nix::fcntl::fcntl(fd, nix::fcntl::F_GETFL).unwrap();
             nix::fcntl::OFlag::from_bits_truncate(flags).contains(nix::fcntl::OFlag::O_NONBLOCK)
         },
-        "a listener reached accept in blocking mode: whoever built it skipped \
-         set_nonblocking, and this call would park the whole executor"
+        "listener is blocking; accept would park the executor"
     );
 
     match sys::accept_syscall(fd.as_raw_fd()) {

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -88,9 +88,7 @@ impl FromRawFd for TcpListener {
     /// Convert an already bound and listening RawFd into a TcpListener
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         let sk = Socket::from_raw_fd(fd);
-        // Same invariant as `bind`, and this is the site that cannot assume
-        // it: the caller built this fd and has no reason to know that an
-        // accept on a blocking listener parks the executor.
+        // The caller built this fd, so it may not be non-blocking yet.
         sk.set_nonblocking(true)
             .expect("failed to put the listener in non-blocking mode");
         let listener = sk.into();
@@ -138,8 +136,7 @@ impl TcpListener {
         let sk = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
         let addr = socket2::SockAddr::from(addr);
         sk.set_reuse_port(true)?;
-        // `yolo_accept` depends on this: a blocking listener parks the whole
-        // executor inside `accept` instead of returning `EAGAIN`.
+        // yolo_accept needs this: a blocking listener parks the executor.
         sk.set_nonblocking(true)?;
         sk.bind(&addr)?;
         sk.listen(1024)?;

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -88,6 +88,11 @@ impl FromRawFd for TcpListener {
     /// Convert an already bound and listening RawFd into a TcpListener
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         let sk = Socket::from_raw_fd(fd);
+        // Same invariant as `bind`, and this is the site that cannot assume
+        // it: the caller built this fd and has no reason to know that an
+        // accept on a blocking listener parks the executor.
+        sk.set_nonblocking(true)
+            .expect("failed to put the listener in non-blocking mode");
         let listener = sk.into();
 
         TcpListener {
@@ -133,6 +138,9 @@ impl TcpListener {
         let sk = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
         let addr = socket2::SockAddr::from(addr);
         sk.set_reuse_port(true)?;
+        // `yolo_accept` depends on this: a blocking listener parks the whole
+        // executor inside `accept` instead of returning `EAGAIN`.
+        sk.set_nonblocking(true)?;
         sk.bind(&addr)?;
         sk.listen(1024)?;
         let listener = sk.into();

--- a/glommio/src/net/unix.rs
+++ b/glommio/src/net/unix.rs
@@ -94,6 +94,8 @@ impl UnixListener {
         let sk = Socket::new(Domain::UNIX, Type::STREAM, None)?;
         let addr = socket2::SockAddr::unix(addr.as_ref())?;
 
+        // See `TcpListener::bind`: `yolo_accept` requires this.
+        sk.set_nonblocking(true)?;
         sk.bind(&addr)?;
         sk.listen(128)?;
         let listener = sk.into();


### PR DESCRIPTION
Three files, +25/-10.

`yolo_accept` flips the listener to non-blocking, accepts, and flips it back:

```rust
let flags = OFlag::from_bits(fcntl(fd, F_GETFL).unwrap()).unwrap();
fcntl(fd, F_SETFL(flags | O_NONBLOCK)).unwrap();
let r = sys::accept_syscall(fd.as_raw_fd());
fcntl(fd, F_SETFL(flags)).unwrap();
```

Four syscalls where it needs one, and three `unwrap`s on a path that runs per
connection. Listeners are put in non-blocking mode when they are constructed
instead, which is what `bind` already does for everything else about them.

### How much it is worth, honestly

In isolation the two extra `fcntl` calls cost about 326ns of CPU per accept.
Inside glommio that is not measurable: 1,838ns of CPU per connection before
against 1,805ns after, with the runs overlapping.

So this is not a performance PR despite the prefix, and I would rather say that
than have someone measure it and find nothing. It is here for being strictly
less work and three fewer panics on the accept path.

### The invariant it introduces

A listener that reaches `accept` in blocking mode would park the whole executor
rather than return `EAGAIN`, which is worse than what it replaces. So all three
construction sites set the flag, and a `debug_assert` in `yolo_accept` says so
loudly rather than hanging if a fourth ever appears. I checked the assert fires
by removing one of the three, rather than assuming it would.

`FromRawFd` is the site that cannot assume the flag: the caller built the
descriptor and has no reason to know what `accept` needs from it. It cannot
return an error, so it expects, with a message naming the cause.

Same origin as #46 and #47: found while reconciling our fork against `main`.
