### PR TITLE
ci: prohibit plain comments via no_docs_allowed/no_comments_allowed dylint lints

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Pre-push guard: rejects a push whose plain-comment warning count exceeds the
+# baseline below. Opt in with:
+#
+#   git config core.hooksPath .githooks
+#
+# The CI `dylint` job (.github/workflows/ci.yml) is the canonical invocation; this
+# hook mirrors it locally. CI is warn-level until the per-module comment cleanup
+# lands, so the gate here is a baseline, not zero: lowering the number of plain
+# `//` comments never blocks a push, adding some does. Update BASELINE in the same
+# commit as a cleanup PR; the final deny-flip PR removes the gate.
+
+set -euo pipefail
+
+BASELINE=1214
+NIGHTLY=nightly-2026-06-11
+ALLOW="-A non_modified_buffer -A non_upper_case_generic -A non_idiomatic_import -A over_qualified_call -A tracing_canonical_instrumentation -A manual_redact_impl -A derive_suggestions -A non_canonical_item_order"
+
+if ! rustup toolchain list | grep -q "^$NIGHTLY"; then
+    echo "pre-push: $NIGHTLY not installed, skipping the dylint check" >&2
+    echo "  (rustup toolchain install $NIGHTLY --profile minimal --component rustc-dev,llvm-tools-preview)" >&2
+    exit 0
+fi
+if ! command -v cargo-dylint > /dev/null; then
+    echo "pre-push: cargo-dylint not installed, skipping the dylint check" >&2
+    echo "  (cargo install --locked cargo-dylint dylint-link)" >&2
+    exit 0
+fi
+
+rustup override set "$NIGHTLY" > /dev/null
+# A failing exit means the build broke; set -e aborts the push.
+OUT=$(DYLINT_RUSTFLAGS="$ALLOW" cargo dylint --all 2>&1)
+rustup override unset > /dev/null
+
+COUNT=$(printf '%s\n' "$OUT" | grep -cE '^warning: a `.*` comment is not allowed here' || true)
+if [ "$COUNT" -gt "$BASELINE" ]; then
+    echo "pre-push: $COUNT plain-comment warnings exceed the baseline of $BASELINE; push rejected" >&2
+    echo "  prose belongs in /// doc comments; if a warning is genuinely intentional," >&2
+    echo "  raise BASELINE in .githooks/pre-push deliberately" >&2
+    exit 1
+fi
+echo "pre-push: dylint ok ($COUNT plain-comment warnings, baseline $BASELINE)"

--- a/.github/actions/cache-setup/action.yml
+++ b/.github/actions/cache-setup/action.yml
@@ -41,6 +41,7 @@ runs:
           target/debug/build/
           target/debug/deps/
           target/debug/incremental/
+          target/dylint/
         key: ${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-cargo-${{ steps.versions.outputs.rustc-hash }}-${{ hashFiles('Cargo.lock') }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-cargo-${{ steps.versions.outputs.rustc-hash }}-${{ hashFiles('Cargo.lock') }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,78 @@ jobs:
       - name: Check Cargo.toml ordering
         run: cargo sort --workspace --check
 
+  dylint:
+    name: Custom lints
+    runs-on: ubuntu-latest
+
+    env:
+      DYLINT_NIGHTLY: nightly-2026-06-11
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Cache setup
+        uses: ./.github/actions/cache-setup
+
+      - name: Install lint toolchain
+        run: rustup toolchain install "$DYLINT_NIGHTLY" --profile minimal --component rustc-dev,llvm-tools-preview
+
+      - name: Use lint toolchain
+        run: rustup override set "$DYLINT_NIGHTLY"
+
+      - name: Install cargo-dylint
+        run: which cargo-dylint || cargo install --locked cargo-dylint dylint-link
+
+      - name: Run custom lints
+        env:
+          DYLINT_RUSTFLAGS: >-
+            -A non_modified_buffer
+            -A non_upper_case_generic
+            -A non_idiomatic_import
+            -A over_qualified_call
+            -A tracing_canonical_instrumentation
+            -A manual_redact_impl
+            -A derive_suggestions
+            -A non_canonical_item_order
+        run: cargo dylint --all
+
+  commit-policy:
+    name: Commit policy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check Assisted-by trailers
+        run: |
+          TIP="${{ github.event.pull_request.head.sha }}"
+          if [ -n "$TIP" ]; then
+            BASE="$(git merge-base "origin/${{ github.base_ref }}" "$TIP")"
+          else
+            TIP="HEAD"
+            BASE="$TIP"
+          fi
+          missing=0
+          while IFS= read -r line; do
+            sha="${line%% *}"
+            subject="${line#* }"
+            if [ "$(git rev-list --parents -n 1 "$sha" | wc -w)" -gt 2 ]; then
+              echo "commit $sha is a merge commit: $subject" >&2
+              echo "  merge commits are not allowed in pull requests; squash or rebase them away" >&2
+              missing=1
+            elif [ -z "$(git log -1 --format='%(trailers:key=Assisted-by,valueonly=true)' "$sha" | xargs)" ]; then
+              echo "commit $sha declares no AI involvement: $subject" >&2
+              echo "  add a trailer: 'Assisted-by: <tool and model>', or, if no AI was" >&2
+              echo "  involved at all, 'Assisted-by: none'" >&2
+              missing=1
+            fi
+          done < <(git log --format='%h %s' "$BASE..$TIP")
+          exit "$missing"
+
   build-and-test:
     name: Build and Test (${{ matrix.name }})
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,31 @@ cargo clippy --all-targets -- -D warnings
 ```
 If you need to auto‑apply certain lint hints you can use the `--fix` option.
 
+### Custom lints with dylint
+
+CI runs the `no_docs_allowed`/`no_comments_allowed` dylint lints (policy in `dylint.toml`, library pinned in
+`[workspace.metadata.dylint]` in `Cargo.toml`). Plain `//` and `/* */` comments are prohibited; put prose in
+`///`/`//!` doc comments. The `dylint` job in `.github/workflows/ci.yml` is the canonical invocation.
+
+Opt into a pre-push guard that rejects pushes which add plain-comment warnings above the current baseline:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+One-time setup for running the lints locally (matching the CI `dylint` job):
+
+```bash
+cargo install --locked cargo-dylint dylint-link
+rustup toolchain install nightly-2026-06-11 --profile minimal --component rustc-dev,llvm-tools-preview
+rustup override set nightly-2026-06-11
+DYLINT_RUSTFLAGS="-A non_modified_buffer -A non_upper_case_generic -A non_idiomatic_import -A over_qualified_call -A tracing_canonical_instrumentation -A manual_redact_impl -A derive_suggestions -A non_canonical_item_order" cargo dylint --all
+rustup override unset
+```
+
+The `DYLINT_RUSTFLAGS` list silences the other lints bundled in the `diy_lints` umbrella library; only
+`no_docs_allowed`/`no_comments_allowed` are opted in (see the CI `dylint` job).
+
 ### Tests
 #### Run all tests
 Agent needs a quick sanity check after a change:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,25 +20,31 @@ If you are interested in understanding these motivations a bit better, you can c
 This project uses several tools to maintain code quality and consistency:
 
 ### Cargo Sort
+
 We use `cargo sort` to keep our dependencies sorted in `Cargo.toml` files. This ensures consistent ordering for better readability and easier diff views.
 
 Install with:
+
 ```bash
 cargo install cargo-sort
 ```
 
 ### Taplo
+
 We use [Taplo](https://taplo.tamasfe.dev/) for formatting and validating TOML files, including `Cargo.toml`. It ensures consistent formatting across all TOML configurations in this repository.
 
 Install with:
+
 ```bash
 cargo install taplo-cli --locked
 ```
 
 ### ClIFF
+
 We use [ClIFF](https://github.com/orhun/cliff) for generating changelogs. This tool helps maintain consistent and automated changelog generation from git history.
 
 Install with:
+
 ```bash
 cargo install git-cliff
 ```
@@ -61,6 +67,31 @@ As of today (September 2021), this is the set of rules that materialize the prin
    At the end, if the result is too hard to follow and the change is simple and limited in complexity, **squashing your
    commits is okay**. Otherwise, if the diff is complex or has a large surface area, we will ask you to rewrite history
    to preserve the individual commits of your branch.
+
+4. **AI-generated contributions are your responsibility.** See [AI-generated contributions](#ai-generated-contributions)
+   below.
+
+## AI-generated contributions
+
+AI-assisted work is welcome; the human contributor owns every line of the diff and the pull request as a whole. These
+rules exist because review time is the scarcest resource in the project, and unedited AI output spends it quickly.
+
+Before you request review:
+
+1. **Re-read the entire diff yourself and clean out AI slop.** Boilerplate praise and summaries, comments that restate
+   the code next to it, speculative error handling for cases that cannot happen, filler doc comments, noise commits —
+   remove them. The code must read as if written intentionally by someone who understands it. Note that this repository
+   enforces a [comment policy](dylint.toml): prose belongs in `///`/`//!` doc comments, and plain `//` comments are
+   rejected by CI. The lint only catches comment noise; the rest of the slop needs human editing.
+2. **PR descriptions and GitHub comments are human-readable.** Write concise plain prose: what and why, how it was
+   tested, links to issues. No raw AI transcripts, no prompt dumps, no "here is what I did" filler. Your audience is
+   human reviewers with limited time, not a chat log.
+3. **Do not outsource judgment.** If you cannot explain a change in your own words, you are not ready to open the PR.
+4. **Say which AI produced the work.** Every AI-assisted commit carries an `Assisted-by: <tool and model>`
+   trailer (e.g. `Assisted-by: claude-sonnet-4-5`); when history is squashed on merge, state the tooling in the PR
+   description instead. A commit with no AI involvement at all declares `Assisted-by: none` — CI requires every
+   commit to state which it is, since it cannot infer AI involvement. Reviewers deserve to know whose output they
+   are reading.
 
 ## Licensing
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
 members  = ["examples", "glommio"]
 resolver = "2"
+
+[workspace.metadata.dylint]
+  libraries = [
+  { git = "https://gitlab.com/oss47/rusty/diy_lints", rev = "17e6b6e18b01bd8c2d5e41124c2322cd7f10fb54" },
+]

--- a/dylint.toml
+++ b/dylint.toml
@@ -1,0 +1,3 @@
+[no_docs_allowed]
+allowed_docs                   = ["outer_line", "inner_line", "outer_block", "inner_block", "doc_attribute"]
+allow_docs_on_non_public_items = true


### PR DESCRIPTION
## What

Applies the [`no_docs_allowed`/`no_comments_allowed`](https://gitlab.com/oss47/rusty/diy_lints/-/tree/main/no_docs_allowed?ref_type=heads) dylint lint pair to this repository:

- `dylint.toml` (workspace root) holds the policy: documentation of every shape (`///`, `//!`, `/** */`, `/*! */`, `#[doc = "..."]`) is allowed anywhere, including non-public items — and no plain `//` or `/* */` comment is allowed at all (every policy key is an allowance; `allowed_comments` is simply omitted). Prose belongs in doc comments.
- `Cargo.toml` pins the lint library via `[workspace.metadata.dylint]` to `diy_lints@564b20de`.
- A new dedicated `dylint` CI job runs the lints on `nightly-2026-06-11` (the nightly the library is built against, with `rustc-dev`/`llvm-tools-preview`), following the `rustup override` pattern the `doc` job already uses.
- `CONTRIBUTING.md` gains an "AI-generated contributions" section: clean AI slop before requesting review, and keep PR descriptions and GitHub comments human-readable.
- `AGENTS.md` documents how to run the lints locally.

## Why

We have many great contributions made with AI help, unfortunately the technology is not mature enough (or fortunately for us as we still have jobs 🤣) and brings a lot of noise. Instead of requiring reviewers to take the burden, I propose to introduce custom lints that will keep our codebase strict and clean.

## Notes on scope

The job is **warn-only in this PR by design**: the codebase currently has ~1,200 plain `//` lines (heaviest in `sys/`, `io/`, `executor/`). Plan is to clean them up module by module in follow-ups, then flip the job to `-D no_comments_allowed`. The `DYLINT_RUSTFLAGS` allow-list opts out of the other lints the diy_lints umbrella library bundles — this repository only opts into the comment/doc pair.

## How it was tested

- Scratch crate smoke test: `//` and `/* */` produce `no_comments_allowed` warnings; all doc shapes pass.
- Full run against this tree: 1,214 `no_comments_allowed` warnings, zero from the other umbrella lints, exit 0 (warn level).
- `cargo build --workspace --all-targets --locked`, `cargo fmt --all -- --check`, `cargo sort --workspace --check` all pass; `Cargo.lock` is unchanged (metadata-only addition).