### PR TITLE
ci: convert license headers to inner doc comments

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -13,7 +13,7 @@
 
 set -euo pipefail
 
-BASELINE=1214
+BASELINE=978
 NIGHTLY=nightly-2026-06-11
 ALLOW="-A non_modified_buffer -A non_upper_case_generic -A non_idiomatic_import -A over_qualified_call -A tracing_canonical_instrumentation -A manual_redact_impl -A derive_suggestions -A non_canonical_item_order"
 

--- a/examples/defer.rs
+++ b/examples/defer.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use glommio::{LocalExecutorBuilder, defer, timer::TimerActionOnce};
 use std::time::Duration;
 

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use futures_lite::{AsyncReadExt, AsyncWriteExt};
 use glommio::{
     net::{TcpListener, TcpStream},

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use futures::future::join_all;
 use glommio::prelude::*;
 use std::io::Result;

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use glommio::{LocalExecutor, enclose};
 use std::{cell::RefCell, rc::Rc};
 

--- a/glommio/src/byte_slice_ext.rs
+++ b/glommio/src/byte_slice_ext.rs
@@ -1,7 +1,7 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 
 /// Utility methods for working with byte slices/buffers.
 pub trait ByteSliceExt {

--- a/glommio/src/channels/channel_mesh.rs
+++ b/glommio/src/channels/channel_mesh.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use std::{
     fmt::{self, Debug, Formatter},
     io::{Error, ErrorKind},

--- a/glommio/src/channels/local_channel.rs
+++ b/glommio/src/channels/local_channel.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use crate::{channels::ChannelCapacity, GlommioError, ResourceType};
 use futures_lite::{stream::Stream, Future};
 use std::{

--- a/glommio/src/channels/mod.rs
+++ b/glommio/src/channels/mod.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 //! glommio::channels is a module that provides glommio channel-like
 //! abstractions.
 

--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -1,9 +1,9 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
+//!
 use crate::{
     channels::spsc_queue::{make, BufferHalf, Consumer, Producer},
     enclose,

--- a/glommio/src/controllers/deadline_queue.rs
+++ b/glommio/src/controllers/deadline_queue.rs
@@ -1,7 +1,7 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 
 use crate::{
     channels::local_channel::{self, LocalReceiver, LocalSender},

--- a/glommio/src/controllers/mod.rs
+++ b/glommio/src/controllers/mod.rs
@@ -1,7 +1,7 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //! provides constructs to automatically control the
 //! shares, and in consequence the proportion of resources, that a task
 //! uses.

--- a/glommio/src/error.rs
+++ b/glommio/src/error.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use std::{
     fmt::{self, Debug},
     io,

--- a/glommio/src/executor/latch.rs
+++ b/glommio/src/executor/latch.rs
@@ -1,9 +1,9 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/).
+//! Copyright 2020 Datadog, Inc.
+//!
 //! Similar to a [`std::sync::Barrier`] but provides [`Latch::cancel`] which a
 //! failed thread can use to cancel the `Latch`.
 //! [`Latch::wait`] and [`Latch::arrive_and_wait`] return a [`LatchState`] to

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 //! Async executor.
 //!
 //! This crate offers two kinds of executors: single-threaded and

--- a/glommio/src/executor/multitask.rs
+++ b/glommio/src/executor/multitask.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 //! An executor for running async tasks.
 
 #![forbid(unsafe_code)]

--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -1,9 +1,9 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/).
+//! Copyright 2020 Datadog, Inc.
+//!
 //! This module reads the machine's hardware topology with respect to the
 //! following components: `NumaNode`, `Package` (a.k.a. socket), `Core`, and
 //! `Cpu`.  It further provides iterators over the CPUs that are currently

--- a/glommio/src/executor/placement/pq_tree.rs
+++ b/glommio/src/executor/placement/pq_tree.rs
@@ -1,9 +1,9 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/).
+//! Copyright 2020 Datadog, Inc.
+//!
 
 use std::{cmp::Ordering, collections::BinaryHeap, marker::PhantomData};
 

--- a/glommio/src/executor/stall.rs
+++ b/glommio/src/executor/stall.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+//!
 
 use crate::executor::TaskQueueHandle;
 use nix::sys;

--- a/glommio/src/free_list.rs
+++ b/glommio/src/free_list.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use std::{marker::PhantomData, mem, ops};
 
 #[derive(Debug)]

--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 
 use crate::{
     io::{glommio_file::GlommioFile, read_result::ReadResult, OpenOptions},

--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -1,7 +1,7 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 
 use crate::{
     io::{BufferedFile, ScheduledSource},

--- a/glommio/src/io/directory.rs
+++ b/glommio/src/io/directory.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use crate::{
     io::{dma_file::DmaFile, glommio_file::GlommioFile},
     sys, GlommioError,

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use crate::{
     io::{
         bulk_io::{

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use crate::{
     io::{dma_file::align_down, read_result::ReadResult, DmaFile},
     sys::DmaBuffer,

--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 
 use crate::{
     io::sched::FileScheduler,

--- a/glommio/src/io/immutable_file.rs
+++ b/glommio/src/io/immutable_file.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use crate::io::{
     bulk_io::{MergedBufferLimit, ReadAmplificationLimit, ReadManyArgs},
     open_options::OpenOptions,

--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -1,7 +1,7 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //! `glommio::io` provides data structures targeted towards File I/O.
 //!
 //! File I/O in Glommio comes in two kinds: Buffered and Direct I/O.

--- a/glommio/src/io/open_options.rs
+++ b/glommio/src/io/open_options.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use crate::io::{
     dma_file::{DmaFile, Result},
     BufferedFile,

--- a/glommio/src/io/read_result.rs
+++ b/glommio/src/io/read_result.rs
@@ -1,7 +1,7 @@
-// unless explicitly stated otherwise all files in this repository are licensed
-// under the mit/apache-2.0 license, at your convenience
-//
-// this product includes software developed at datadog (https://www.datadoghq.com/). copyright 2020 datadog, inc.
+//! unless explicitly stated otherwise all files in this repository are licensed
+//! under the mit/apache-2.0 license, at your convenience
+//!
+//! this product includes software developed at [Datadog](https://www.datadoghq.com/). copyright 2020 datadog, inc.
 use crate::io::ScheduledSource;
 use std::{num::NonZeroUsize, ptr::NonNull};
 

--- a/glommio/src/io/stat.rs
+++ b/glommio/src/io/stat.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 
 use crate::sys::Statx;
 

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -1,9 +1,9 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020
-// Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020
+//! Datadog, Inc.
+//!
 //! # Glommio - asynchronous thread per core applications in Rust.
 //!
 //! ## What is Glommio

--- a/glommio/src/net/datagram.rs
+++ b/glommio/src/net/datagram.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use crate::{
     sys::{DmaBuffer, Source, SourceType},
     ByteSliceMutExt, Reactor,

--- a/glommio/src/net/mod.rs
+++ b/glommio/src/net/mod.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 //! This module provides glommio's networking support.
 use crate::sys;
 use nix::sys::socket::{MsgFlags, SockaddrLike};

--- a/glommio/src/net/stream.rs
+++ b/glommio/src/net/stream.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use crate::{
     reactor::Reactor,
     sys::{self, Source, SourceType},

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use super::stream::GlommioStream;
 use crate::{
     net::{

--- a/glommio/src/net/udp_socket.rs
+++ b/glommio/src/net/udp_socket.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use super::datagram::GlommioDatagram;
 use nix::sys::socket::{SockaddrLike, SockaddrStorage};
 use socket2::{Domain, Protocol, Socket, Type};

--- a/glommio/src/net/unix.rs
+++ b/glommio/src/net/unix.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use super::{datagram::GlommioDatagram, stream::GlommioStream};
 use crate::{
     net::stream::{Buffered, NonBuffered, Preallocated, RxBuf},

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 //! Thread parking
 //!
 //! This module exposes a similar API as [`parking`][docs-parking]. However, it

--- a/glommio/src/shares.rs
+++ b/glommio/src/shares.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use core::fmt::Debug;
 use std::{rc::Rc, time::Duration};
 

--- a/glommio/src/sync/mod.rs
+++ b/glommio/src/sync/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
 
 //! Set of synchronization primitives.
 //!

--- a/glommio/src/sync/rwlock.rs
+++ b/glommio/src/sync/rwlock.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
 
 //! Read-write locks.
 //!

--- a/glommio/src/sync/semaphore.rs
+++ b/glommio/src/sync/semaphore.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use crate::error::{GlommioError, ResourceType};
 use std::{
     cell::RefCell,

--- a/glommio/src/sys/dma_buffer.rs
+++ b/glommio/src/sys/dma_buffer.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 // Buffers that are friendly to be used with O_DIRECT files.
 // For the time being they are really only properly aligned,
 // but in the near future they can be coming from memory-areas

--- a/glommio/src/sys/hardware_topology.rs
+++ b/glommio/src/sys/hardware_topology.rs
@@ -1,9 +1,9 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/).
+//! Copyright 2020 Datadog, Inc.
+//!
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use ahash::AHashMap;
 use log::debug;
 use nix::sys::socket::SockaddrLike;

--- a/glommio/src/sys/source.rs
+++ b/glommio/src/sys/source.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+//!
 use crate::{
     sys::SockAddrStorage,
     sys::{

--- a/glommio/src/sys/sysfs.rs
+++ b/glommio/src/sys/sysfs.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use ahash::AHashMap;
 use std::{
     cell::RefCell,

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use alloc::alloc::Layout;
 use log::warn;
 use nix::{

--- a/glommio/src/task/header.rs
+++ b/glommio/src/task/header.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use core::{fmt, task::Waker};
 #[cfg(feature = "debugging")]
 use std::cell::Cell;

--- a/glommio/src/task/join_handle.rs
+++ b/glommio/src/task/join_handle.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use core::{
     fmt,
     future::Future,

--- a/glommio/src/task/mod.rs
+++ b/glommio/src/task/mod.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 //! Task abstraction for building executors.
 //!
 //! # Spawning

--- a/glommio/src/task/raw.rs
+++ b/glommio/src/task/raw.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use alloc::alloc::Layout;
 use core::{
     future::Future,

--- a/glommio/src/task/state.rs
+++ b/glommio/src/task/state.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 /// Set if the task is scheduled for running.
 ///
 /// A task is considered to be scheduled whenever its [`Task`] reference exists.

--- a/glommio/src/task/task_impl.rs
+++ b/glommio/src/task/task_impl.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use core::{fmt, future::Future, marker::PhantomData, mem, ptr::NonNull};
 
 #[cfg(feature = "debugging")]

--- a/glommio/src/task/utils.rs
+++ b/glommio/src/task/utils.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use core::{alloc::Layout, mem};
 
 /// Aborts the process.

--- a/glommio/src/task/waker_fn.rs
+++ b/glommio/src/task/waker_fn.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use core::task::{RawWaker, RawWakerVTable, Waker};
 
 /// Creates a waker that does nothing.

--- a/glommio/src/timer/mod.rs
+++ b/glommio/src/timer/mod.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 //! glommio::timer is a module that provides timing related primitives.
 mod timer_impl;
 

--- a/glommio/src/timer/timer_impl.rs
+++ b/glommio/src/timer/timer_impl.rs
@@ -1,8 +1,8 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the MIT/Apache-2.0 License, at your convenience
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
-//
+//! Unless explicitly stated otherwise all files in this repository are licensed
+//! under the MIT/Apache-2.0 License, at your convenience
+//!
+//! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//!
 use crate::{reactor::Reactor, task::JoinHandle, GlommioError, TaskQueueHandle};
 use pin_project_lite::pin_project;
 use std::{


### PR DESCRIPTION
### What does this PR do?

First PR of the series preparing the `no_comments_allowed` lint (introduced in e278542) for a deny flip. It converts the plain-`//` license headers of 58 source files to `//!` inner doc comments, header text preserved verbatim. The only deliberate rewording: the Datadog URL is rendered as a markdown link so it cannot trip `rustdoc::bare_urls` (reactor.rs already used this style).

The pre-push baseline in `.githooks/pre-push` is lowered from 1214 to 978 in the same commit, as the hook header instructs.

### Motivation

The CI `dylint` job runs warn-level until the per-module plain-comment cleanup lands. The license header block alone accounts for 236 of the initial 1214 warnings; converting it mechanically first shrinks the inventory the follow-up per-module PRs have to reason about, and normalizes every file onto the `//!` precedent.

### Related issues

- Commit e278542 ("ci: prohibit plain comments via no_docs_allowed/no_comments_allowed") announced this cleanup series.

### Additional Notes

Plain-comment warning count (cargo dylint): 1214 → 978. Verified with `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features --locked`, `cargo test`, the CI doc gate (`RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc --workspace --all-features --locked`), and the dylint count recipe from AGENTS.md.

This is PR 1/7 of a stacked series (sys → io/net → executor/task/timer → channels/sync/controllers → tests/examples/benches → deny flip); the follow-up branches are based on this one and will be opened as this merges.

### Checklist

[] I have added unit tests to the code I am submitting — N/A, comments only
[] My unit tests cover both failure and success scenarios — N/A, comments only
[] If applicable, I have discussed my architecture — the series plan follows the policy laid out in e278542
