### PR TITLE
build: stop pinning musl-gcc as the musl linker

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,2 @@
 [net]
 git-fetch-with-cli = true
-
-[target.x86_64-unknown-linux-musl]
-linker = "musl-gcc"


### PR DESCRIPTION
### What does this PR do?

Removes three lines from `.cargo/config.toml`:

```toml
[target.x86_64-unknown-linux-musl]
linker = "musl-gcc"
```

### Motivation

`rustup target add x86_64-unknown-linux-musl` ships a self-contained musl: the crt objects and `libc.a` come with the target, and the default linker driver knows how to use them. Pinning `musl-gcc` overrides that with whichever musl the host distribution installed, and its startup objects do not necessarily match the ones rustc supplies.

Where they disagree, the binary links without complaint and then dies inside musl's own `_start_c`, before `main`, on every single test:

```
Program received signal SIGSEGV, Segmentation fault.
#0  _start_c () at ../src_musl/crt/../ldso/dlstart.c:141
```

There is no error message and nothing points at the linker, so it reads as a bug in the crate. It works on the CI image because Ubuntu's `musl-tools` happens to agree with rustc's objects; it does not work on Arch, and I would not expect it to be reliable on any distribution that packages musl differently.

The pin appears to date from 8522405, when the crate still built vendored `liburing` sources and needed a musl-aware C compiler. Nothing in the workspace compiles C any more: `glommio/build.rs` only sets the `nightly` cfg, and there is no `cc` build-dependency, so the linker driver has no C to handle.

### Related issues

N/A

### Testing

With the pin removed, no host musl toolchain installed and no environment overrides:

```
cargo nextest run --lib --target x86_64-unknown-linux-musl
    Summary  408 tests run: 408 passed, 0 skipped

cargo nextest run --lib
    Summary  408 tests run: 408 passed, 0 skipped
```

### Additional notes

I have not touched `.github/actions/setup-musl`. It installs `musl-tools` and `linux-libc-dev` and symlinks the kernel headers into the musl include path, all of which existed to serve `musl-gcc`. That action may now be reducible to `rustup target add`, but I cannot test your runner, so I would rather change one thing and let you decide about CI separately.

### Checklist

[ ] I have added unit tests to the code I am submitting
[ ] My unit tests cover both failure and success scenarios
[ ] If applicable, I have discussed my architecture
[X] GitHub description authored by hand

No new tests: this is a build configuration change, and the evidence is the existing suite passing on both targets where it previously could not run at all.
