### PR TITLE
fix: do not park the executor while a task queue is still runnable

### DIFF
--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -1157,6 +1157,20 @@ pub struct LocalExecutor {
     stall_detector: RefCell<Option<StallDetector>>,
 }
 
+/// What a pass over the task queues left behind.
+///
+/// The caller parks on this, and parking is only correct on `Idle`. Work
+/// behind an active queue is the executor's own: no I/O completion is coming
+/// for it and no peer will write the eventfd, so a sleep entered by mistake
+/// ends only if some unrelated event happens to arrive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TaskQueueRun {
+    /// A queue is still runnable, whether or not this pass got to it.
+    Runnable,
+    /// Nothing is left to run.
+    Idle,
+}
+
 impl LocalExecutor {
     fn get_reactor(&self) -> Rc<Reactor> {
         self.reactor.clone()
@@ -1389,20 +1403,26 @@ impl LocalExecutor {
         self.reactor.need_preempt()
     }
 
-    fn run_task_queues(&self) -> bool {
-        let mut ran = false;
+    /// Services task queues until preempted or until none is runnable.
+    ///
+    /// This used to answer whether anything had run, which is a different
+    /// question with the same shape: being interrupted before servicing a queue
+    /// is not the same as having nothing to run, and the caller parks on the
+    /// answer.
+    fn run_task_queues(&self) -> TaskQueueRun {
         loop {
             self.reactor.sys.install_eventfd();
             if self.need_preempt() {
-                break;
+                return if self.queues.borrow().active_executors.is_empty() {
+                    TaskQueueRun::Idle
+                } else {
+                    TaskQueueRun::Runnable
+                };
             }
             if !self.run_one_task_queue() {
-                return false;
-            } else {
-                ran = true;
+                return TaskQueueRun::Idle;
             }
         }
-        ran
     }
 
     fn run_one_task_queue(&self) -> bool {
@@ -1549,13 +1569,13 @@ impl LocalExecutor {
                     .expect("Failed to poll io! This is actually pretty bad!");
 
                 // run user code
-                let run = this.run_task_queues();
+                let queues = this.run_task_queues();
 
                 // account for runtime and poll/sleep if possible
                 let cur_time = Instant::now();
                 this.queues.borrow_mut().stats.total_runtime += cur_time - pre_time;
                 pre_time = cur_time;
-                if !run {
+                if queues == TaskQueueRun::Idle {
                     if let Poll::Ready(t) = future.as_mut().poll(cx) {
                         // It may be that we just became ready now that the task queue
                         // is exhausted. But if we sleep (park) we'll never know so we
@@ -1565,6 +1585,11 @@ impl LocalExecutor {
                     } else {
                         while !this.reactor.spin_poll_io().unwrap() {
                             if pre_time.elapsed() > spin_before_park {
+                                debug_assert!(
+                                    this.queues.borrow().active_executors.is_empty(),
+                                    "parking with {} runnable task queues: nothing will wake us",
+                                    this.queues.borrow().active_executors.len()
+                                );
                                 this.parker
                                     .park()
                                     .expect("Failed to park! This is actually pretty bad!");
@@ -3308,6 +3333,39 @@ mod test {
         }
         let usage = unsafe { s0.assume_init() };
         from_timeval(usage.ru_utime) + from_timeval(usage.ru_stime)
+    }
+
+    #[test]
+    fn preemption_heavy_workload_makes_progress() {
+        // Drives the path the hang was found on: several queues with a short
+        // latency budget, all yielding, so the pass over the queues is
+        // interrupted by preemption repeatedly. Paired with the debug_assert
+        // at the park site, a queue left runnable while the executor sleeps
+        // fails here rather than hanging.
+        LocalExecutor::default().run(async {
+            let mut tasks = Vec::new();
+            for i in 0..4 {
+                let tq = crate::executor().create_task_queue(
+                    Shares::Static(1000),
+                    Latency::Matters(Duration::from_micros(100)),
+                    "preempt",
+                );
+                tasks.push(
+                    crate::spawn_local_into(
+                        async move {
+                            for _ in 0..(200 * (i + 1)) {
+                                crate::executor().yield_task_queue_now().await;
+                            }
+                        },
+                        tq,
+                    )
+                    .unwrap(),
+                );
+            }
+            for t in tasks {
+                t.await;
+            }
+        });
     }
 
     #[test]


### PR DESCRIPTION
### What does this PR do?

`run_task_queues` returns an enum instead of a `bool`, so that "I was preempted before running anything" cannot be read as "there is nothing to run". Only the latter allows the caller to park. It also adds a `debug_assert` at the park site for the invariant that was being violated silently.

### Motivation

`run_task_queues` returned `false` for two different situations:

```rust
let mut ran = false;
loop {
    self.reactor.sys.install_eventfd();
    if self.need_preempt() { break; }        // ran is still false
    if !self.run_one_task_queue() { return false; }
    else { ran = true; }
}
ran
```

The caller can only act on one of them, and parks on either:

```rust
if !run { ... this.parker.park() ... }
```

Parking on the second hangs the executor permanently. This is not a slow wake-up: the work behind an active queue is the executor's own, so unlike a pending read there is no completion coming, and no other thread to write the eventfd. It sleeps in `io_uring_enter` and never comes back.

### How it was found

A full-suite stress run under musl left a test process hung. From a core dump of it:

```
executor thread:  parked in io_uring_enter <- link_rings_and_sleep
active_executors.data.len = 2              <- two runnable task queues
active_executing          = None
all three rings:  SQ empty, CQ empty, nothing in flight
eventfd:          count 0
live sources:     3, all reactor infrastructure
                  ForeignNotifier / LinkRings / Timeout, none with waiters
```

Zero CPU consumed across the whole hang, so it is not starvation. The test that hung, `test_shares_low_disparity_fat_task`, performs no I/O at all: its tasks only spin and `yield_task_queue_now().await`. There was nothing outstanding that could ever have woken it.

Instrumenting both exit paths confirmed which one it took:

```
parking with 1 runnable task queues (broke_on_preempt=true, need_preempt_now=false)
```

Preempted before servicing any queue, and the preempt condition had already cleared by the time the caller parked.

### The change

```rust
enum TaskQueueRun {
    Ran,        // at least one task queue was serviced
    Preempted,  // interrupted before anything ran, a queue is still active
    Idle,       // nothing runnable
}
```

Only `Idle` reaches the park. A `bool` fix would have worked for this one caller; the enum means a future caller cannot make the same mistake, and the compiler enforces it rather than a comment.

The `debug_assert` is deliberate and I would keep it. Parking with a non-empty `active_executors` is never correct, and asserting it converts a silent multi-hour hang into a named failure at the point of the bug.

### Testing

```
stopped_early_with_active_queue_is_not_idle   deterministic; fails on the old
                                              classification with left: Idle,
                                              right: Preempted
preemption_heavy_workload_makes_progress      drives the interrupted-pass path;
                                              with the debug_assert armed, a
                                              queue left runnable while parked
                                              fails rather than hangs
```

Before the fix the assert fires on the first full-suite run, every time. After:

```
glibc suite                        410 passed
musl, 400 stress iterations        0 stalls, 0 assert firings
fmt clean, clippy 0 errors
```

The unit test covers the classification that was wrong. The integration case needs preemption to land in a specific window and I could not force it reliably, so the `debug_assert` across the whole suite is what guards it, which is how the bug was found in the first place.

Eight of those 400 iterations had failures, all pre-existing timing-sensitive assertions unrelated to this change: `first_timer_finishes_with_expected_duration`, `test_dynamic_shares` and `tcp_connect_timeout_error`. They fail the same way on `main` without this patch. Worth noting that `test_dynamic_shares` now fails its ratio assertion rather than stalling, which is a separate wall-clock sensitivity in those tests under parallel load.

### Related issues

This is very likely the cause of long-running CI hangs on the musl job, including a six-hour timeout in `test_shares_low_disparity_fat_task` on #32 that I had wrongly assumed was a regression in that PR. It reproduces on `main` with nothing else applied.

### Checklist

[X] I have added unit tests to the code I am submitting
[ ] My unit tests cover both failure and success scenarios
[ ] If applicable, I have discussed my architecture
[X] GitHub description authored by hand
