### PR TITLE
ci: prohibit plain comments in src/sys/

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -13,7 +13,7 @@
 
 set -euo pipefail
 
-BASELINE=978
+BASELINE=723
 NIGHTLY=nightly-2026-06-11
 ALLOW="-A non_modified_buffer -A non_upper_case_generic -A non_idiomatic_import -A over_qualified_call -A tracing_canonical_instrumentation -A manual_redact_impl -A derive_suggestions -A non_canonical_item_order"
 

--- a/glommio/src/sys/blocking.rs
+++ b/glommio/src/sys/blocking.rs
@@ -22,8 +22,8 @@ use std::{
 
 use super::membarrier;
 
-// So hard to copy/clone io::Error, plus need to send between threads. Best to
-// do all i64.
+/// So hard to copy/clone `io::Error`, plus need to send between threads. Best to
+/// do all i64.
 macro_rules! raw_syscall {
     ($fn:ident $args:tt) => {{
         let res = unsafe { libc::$fn $args };
@@ -152,8 +152,9 @@ pub(super) struct BlockingThreadResp {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)] // Clippy is unhappy with some of the fields on these enums never being read,
-                    // but they are certainly used, and read by debug
+/// Clippy is unhappy with some of the fields on these enums never being read,
+/// but they are certainly used, and read by debug
+#[allow(dead_code)]
 struct BlockingThread(JoinHandle<()>);
 
 impl BlockingThread {
@@ -191,16 +192,19 @@ pub(crate) struct BlockingThreadPool {
 }
 
 impl BlockingThreadPool {
+    /// Make sure to initialize the membarrier before the thread pool is constructed
+    /// so that registration is much cheaper. Additionally, even if we take the
+    /// expensive slow path, we do it here instead of at the reactor hot loop which
+    /// synchronously blocks the io_uring loop to register the membarrier.
+    /// See <https://github.com/DataDog/glommio/issues/652>.
+    ///
+    /// An alternative solution is to pull in <https://crates.io/crates/ctor> as a
+    /// dependency and run this that way - then the public API to call `early_init`
+    /// can be elided wholesale.
     pub(crate) fn new(
         placement: PoolPlacement,
         sleep_notifier: Arc<SleepNotifier>,
     ) -> crate::Result<Self, ()> {
-        // Make sure to initialize the membarrier before the thread pool is constructed so that registration
-        // is much cheaper. Additionally, even if we take the expensive slow path, we do it here instead
-        // of at the reactor hot loop which synchronously blocks the io_uring loop to register the membarrier.
-        // https://github.com/DataDog/glommio/issues/652
-        // An alternative solution is to pull in https://crates.io/crates/ctor as a dependency and run this
-        // that way - then the public API to call early_init can be elided wholesale.
         membarrier::initialize_strategy();
 
         let (in_tx, in_rx) = flume::bounded(4 << 10);

--- a/glommio/src/sys/dma_buffer.rs
+++ b/glommio/src/sys/dma_buffer.rs
@@ -3,10 +3,10 @@
 //!
 //! This product includes software developed at [Datadog](https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //!
-// Buffers that are friendly to be used with O_DIRECT files.
-// For the time being they are really only properly aligned,
-// but in the near future they can be coming from memory-areas
-// that are pre-registered for I/O uring.
+//! Buffers that are friendly to be used with O_DIRECT files.
+//! For the time being they are really only properly aligned,
+//! but in the near future they can be coming from memory-areas
+//! that are pre-registered for I/O uring.
 
 use std::ptr;
 
@@ -89,7 +89,7 @@ impl BufferStorage {
 /// suitable for io_uring's Direct I/O.
 pub struct DmaBuffer {
     storage: BufferStorage,
-    // Invariant: trim + size are at most one byte past the original allocation.
+    /// Invariant: `trim` + `size` are at most one byte past the original allocation.
     trim: usize,
     size: usize,
 }

--- a/glommio/src/sys/hardware_topology.rs
+++ b/glommio/src/sys/hardware_topology.rs
@@ -43,6 +43,11 @@ pub struct CpuLocation {
     pub cache_domain: usize,
 }
 
+/// Builds the `CpuLocation` for a single CPU from its sysfs topology files.
+///
+/// The `cache_domain` is provisional here: it is replaced with a dense id
+/// below, or left as the package id if this machine does not report cache
+/// topology.
 fn build_cpu_location(
     sysfs_path: &Path,
     cpu: usize,
@@ -60,8 +65,6 @@ fn build_cpu_location(
         core: get_core_id(cpu, &cpu_path, cpu_to_core)?,
         package: package_id,
         numa_node,
-        // Provisional: replaced with a dense id below, or left as the package
-        // id if this machine does not report cache topology.
         cache_domain: get_cache_domain_id(sysfs_path, cpu).unwrap_or(package_id),
     })
 }
@@ -73,7 +76,7 @@ fn build_cpu_location(
 /// a domain derives the same value without any cross-CPU coordination. Returns
 /// `None` when the machine does not expose cache topology at all (some
 /// containers, some architectures), in which case the caller falls back to the
-/// package.
+/// package. Instruction caches are never the sharing domain we care about.
 fn get_cache_domain_id(sysfs_path: &Path, cpu: usize) -> Option<usize> {
     let cache_path = sysfs_path.join(format!("cpu/cpu{cpu}/cache"));
     let mut best: Option<(usize, usize)> = None;
@@ -96,7 +99,6 @@ fn get_cache_domain_id(sysfs_path: &Path, cpu: usize) -> Option<usize> {
             Err(_) => continue,
         };
 
-        // Instruction caches are never the sharing domain we care about.
         if matches!(
             std::fs::read_to_string(dir.join("type"))
                 .as_deref()
@@ -123,7 +125,19 @@ fn get_cache_domain_id(sysfs_path: &Path, cpu: usize) -> Option<usize> {
 
 /// Request the machine topology.  Only CPUs that are currently `online`
 /// according to `/sys/devices/system/cpu/online` are provided;  `sysfs` is
-/// always at `/sys` per: https://www.kernel.org/doc/html/latest/admin-guide/sysfs-rules.html
+/// always at `/sys` per: <https://www.kernel.org/doc/html/latest/admin-guide/sysfs-rules.html>
+///
+/// Assigns a virtual core id to each CPU. The basic strategy is to sort CPUs
+/// by their (NUMA node id, core id) and assign virtual core id in this order.
+/// Note we need to ensure that the CPUs on the same core will have the same
+/// core id. A `BTree` is used over `HashMap` for 2 reasons:
+/// 1. to keep mapping consitent between different invocations.
+/// 2. to assign smaller virtual core ids to smaller numa node id.
+///
+/// Densifies cache domain ids the same way, and for the same reason: the
+/// placement tree assumes ids at a level are unique and consecutive, and the
+/// raw value so far is "lowest CPU sharing this cache", which is neither.
+/// `BTreeMap` keeps the mapping stable across invocations.
 pub fn get_machine_topology_unsorted() -> io::Result<Vec<CpuLocation>> {
     let sysfs_path = Path::new("/sys/devices/system");
     let mut cpus_online = HashSet::new();
@@ -155,7 +169,6 @@ pub fn get_machine_topology_unsorted() -> io::Result<Vec<CpuLocation>> {
         let node_cpus = ListIterator::from_path(&node_path.join("cpulist"))?;
         for cpu in node_cpus {
             let cpu = cpu?;
-            // only map CPUs that are online
             if !cpus_online.contains(&cpu) {
                 continue;
             }
@@ -165,15 +178,6 @@ pub fn get_machine_topology_unsorted() -> io::Result<Vec<CpuLocation>> {
         }
     }
 
-    // Assign a virtual core id to each CPU. The basic strategy is to sort CPUs
-    // by their (NUMA node id, core id) and assign virtual core id in this order.
-    // Note we need to ensure that the CPUs on the same core will have the same core
-    // id.
-
-    // Using BTree over HashMap for 2 reasons:
-    // 1. to keep mapping consitent between different invocations.
-    // 2. to assign smaller virtual core ids to smaller numa node id.
-    // numa_node -> (core_id -> [cpu_id])
     let mut node_to_core_to_cpus: BTreeMap<usize, BTreeMap<usize, Vec<usize>>> = BTreeMap::new();
     for l in &cpu_locations {
         node_to_core_to_cpus
@@ -199,10 +203,6 @@ pub fn get_machine_topology_unsorted() -> io::Result<Vec<CpuLocation>> {
         cpu_location.core = *cpu_to_vcore.get(&cpu_location.cpu).unwrap();
     }
 
-    // Densify cache domain ids the same way, and for the same reason: the
-    // placement tree assumes ids at a level are unique and consecutive, and the
-    // raw value so far is "lowest CPU sharing this cache", which is neither.
-    // BTreeMap keeps the mapping stable across invocations.
     let raw_domains: std::collections::BTreeSet<usize> =
         cpu_locations.iter().map(|l| l.cache_domain).collect();
     let domain_to_dense: HashMap<usize, usize> = raw_domains
@@ -217,15 +217,18 @@ pub fn get_machine_topology_unsorted() -> io::Result<Vec<CpuLocation>> {
     Ok(cpu_locations)
 }
 
+/// Resolves the core id for `cpu` (and all of its hyper-thread siblings).
+///
+/// `hwloc` suggests that some hardware assigns unique `core_id`s to each CPU
+/// even though they are hyper-threads, so we ensure we have the same
+/// `core_id` for all CPUs in `core_cpus_list` (`thread_siblings` is
+/// deprecated in favor of `core_cpus`) see:
+/// <https://github.com/open-mpi/hwloc/blob/3c8ed197d9a017ca5399007861981b60032e7ca6/hwloc/topology-linux.c#L4267>
 fn get_core_id(
     cpu: usize,
     cpu_path: &Path,
     cpu_to_core: &mut HashMap<usize, usize>,
 ) -> io::Result<usize> {
-    // `hwloc` suggests that some hardware assigns unique `core_id`s to each CPU
-    // even though they are hyper-threads, so we ensure we have the same
-    // `core_id` for all CPUs in `core_cpus_list` (`thread_siblings` is
-    // deprecated in favor of `core_cpus`) see: https://github.com/open-mpi/hwloc/blob/3c8ed197d9a017ca5399007861981b60032e7ca6/hwloc/topology-linux.c#L4267
     let cpu_siblings = ListIterator::from_path(&cpu_path.join("core_cpus_list"))?;
     match cpu_to_core.get(&cpu) {
         Some(core) => Ok(*core),
@@ -246,12 +249,11 @@ fn get_core_id(
 pub(crate) mod test_helpers {
     use super::{CpuLocation, HashMap};
 
+    /// Checks that we don't have a system where any hardware component has an id
+    /// that is not unique system-wide (e.g. both numa node 0 and 1 have a core
+    /// with id 0); this precondition is assumed throughout
     pub fn check_topolgy(mut topology: Vec<CpuLocation>) {
-        // Check that we don't have a system where any hardware component has an id that
-        // is not unique system-wide (e.g. both numa node 0 and 1 have a core
-        // with id 0); this precondition is assumed throughout
         topology.sort_by_key(|l| (l.numa_node, l.package, l.core, l.cpu));
-
         let cpus = topology.into_iter();
         let mut cpu_to_core = HashMap::new();
         let mut core_to_pkg = HashMap::new();
@@ -359,10 +361,10 @@ mod test {
 
     #[test]
     #[should_panic(expected = "unsupported topology hierarchy")]
+    /// Panics because topology levels are unclear:
+    /// numa node 0 is associated with package 0 and 1
+    /// package 1 is associated with numa node 0 and 2
     fn check_topology_check() {
-        // panic because topology level are unclear:
-        // numa node 0 is associated with package 0 and 1
-        // package 1 is associated with numa node 0 and 2
         let topology = vec![
             cpu_loc(0, 0, 0, 0),
             cpu_loc(0, 1, 1, 1),
@@ -406,12 +408,13 @@ mod cache_domain_tests {
         }
 
         /// Adds one cache index for `cpu`, as sysfs would expose it.
+        ///
+        /// Trailing newlines are written, because sysfs has them and the list
+        /// parser relies on it: `skip_delim` leaves the final byte alone so the
+        /// terminator can be checked. A fixture without one hangs.
         fn cache(&self, cpu: usize, index: usize, level: &str, kind: &str, shared: &str) -> &Self {
             let dir = self.0.join(format!("cpu/cpu{cpu}/cache/index{index}"));
             fs::create_dir_all(&dir).expect("create cache index");
-            // Trailing newlines, because sysfs has them and the list parser
-            // relies on it: `skip_delim` leaves the final byte alone so the
-            // terminator can be checked. A fixture without one hangs.
             fs::write(dir.join("level"), format!("{level}\n")).expect("write level");
             fs::write(dir.join("type"), format!("{kind}\n")).expect("write type");
             fs::write(dir.join("shared_cpu_list"), format!("{shared}\n"))
@@ -426,10 +429,10 @@ mod cache_domain_tests {
         }
     }
 
+    /// Two packages of four, sharing an L3 each.
     #[test]
     fn the_domain_is_the_lowest_cpu_sharing_the_deepest_cache() {
         let sysfs = FakeSysfs::new();
-        // Two packages of four, sharing an L3 each.
         for cpu in 0..8 {
             let l3 = if cpu < 4 { "0-3" } else { "4-7" };
             sysfs
@@ -445,11 +448,11 @@ mod cache_domain_tests {
         }
     }
 
+    /// An instruction cache reported at a deeper level than the unified one
+    /// it shares a die with. Taking it would split a domain that is real.
     #[test]
     fn an_instruction_cache_is_not_a_sharing_domain() {
         let sysfs = FakeSysfs::new();
-        // An instruction cache reported at a deeper level than the unified one
-        // it shares a die with. Taking it would split a domain that is real.
         sysfs
             .cache(0, 0, "2", "Unified", "0-1")
             .cache(0, 1, "3", "Instruction", "0");
@@ -468,11 +471,11 @@ mod cache_domain_tests {
         );
     }
 
+    /// Some containers and some architectures expose no cache directory at
+    /// all. The caller falls back to the package id.
     #[test]
     fn a_machine_that_reports_no_cache_topology_has_no_domain() {
         let sysfs = FakeSysfs::new();
-        // Some containers and some architectures expose no cache directory at
-        // all. The caller falls back to the package id.
         assert_eq!(get_cache_domain_id(sysfs.path(), 0), None);
     }
 

--- a/glommio/src/sys/membarrier.rs
+++ b/glommio/src/sys/membarrier.rs
@@ -1,4 +1,4 @@
-// code imported from https://github.com/jeehoonkang/membarrier-rs (seems unmaintained)
+//! Code imported from <https://github.com/jeehoonkang/membarrier-rs> (seems unmaintained)
 #[allow(unused_macros)]
 macro_rules! fatal_assert {
     ($cond:expr) => {
@@ -68,9 +68,11 @@ mod syscall {
     }
 
     /// Returns `true` if the `sys_membarrier` call is available.
+    ///
+    /// Queries which membarrier commands are supported; checks if private
+    /// expedited membarrier is supported, then registers the current process
+    /// as a user of private expedited membarrier.
     pub fn is_supported() -> bool {
-        // Queries which membarrier commands are supported. Checks if private expedited
-        // membarrier is supported.
         let ret = sys_membarrier(membarrier_cmd::MEMBARRIER_CMD_QUERY);
         if ret < 0
             || ret & membarrier_cmd::MEMBARRIER_CMD_PRIVATE_EXPEDITED as libc::c_long == 0
@@ -79,7 +81,6 @@ mod syscall {
             return false;
         }
 
-        // Registers the current process as a user of private expedited membarrier.
         if sys_membarrier(membarrier_cmd::MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED) < 0 {
             return false;
         }
@@ -109,32 +110,28 @@ mod mprotect {
         /// Issues a process-wide barrier by changing access protections of a
         /// single mmap-ed page. This method is not as fast as the
         /// `sys_membarrier()` call, but works very similarly.
+        ///
+        /// The page is ensured to be dirty before we change the protection so
+        /// that we prevent the OS from skipping the global TLB flush. Changing
+        /// a page protection from read + write to none causes the OS to issue
+        /// an interrupt to flush TLBs on all processors. This also results in
+        /// flushing the processor buffers.
         #[inline]
         fn barrier(&self) {
             let page = self.page as *mut libc::c_void;
 
             unsafe {
-                // Lock the mutex.
                 fatal_assert!(libc::pthread_mutex_lock(self.lock.get()) == 0);
 
-                // Set the page access protections to read + write.
                 fatal_assert!(
                     libc::mprotect(page, self.page_size, libc::PROT_READ | libc::PROT_WRITE,) == 0
                 );
 
-                // Ensure that the page is dirty before we change the protection so that we
-                // prevent the OS from skipping the global TLB flush.
                 let atomic_usize = &*(page as *const atomic::AtomicUsize);
                 atomic_usize.fetch_add(1, atomic::Ordering::SeqCst);
 
-                // Set the page access protections to none.
-                //
-                // Changing a page protection from read + write to none causes the OS to issue
-                // an interrupt to flush TLBs on all processors. This also results in flushing
-                // the processor buffers.
                 fatal_assert!(libc::mprotect(page, self.page_size, libc::PROT_NONE) == 0);
 
-                // Unlock the mutex.
                 fatal_assert!(libc::pthread_mutex_unlock(self.lock.get()) == 0);
             }
         }
@@ -143,14 +140,17 @@ mod mprotect {
     lazy_static! {
         /// An alternative solution to `sys_membarrier` that works on older Linux kernels and
         /// x86/x86-64 systems.
+        ///
+        /// The page is locked to ensure that it stays in memory during the two
+        /// `mprotect` calls in `Barrier::barrier()`. If the page was unmapped
+        /// between those calls, they would not have the expected effect of
+        /// generating IPI.
         static ref BARRIER: Barrier = {
             unsafe {
-                // Find out the page size on the current system.
                 let page_size = libc::sysconf(libc::_SC_PAGESIZE);
                 fatal_assert!(page_size > 0);
                 let page_size = page_size as libc::size_t;
 
-                // Create a dummy page.
                 let page = libc::mmap(
                     ptr::null_mut(),
                     page_size,
@@ -162,12 +162,8 @@ mod mprotect {
                 fatal_assert!(page != libc::MAP_FAILED);
                 fatal_assert!((page as libc::size_t).is_multiple_of(page_size));
 
-                // Locking the page ensures that it stays in memory during the two mprotect
-                // calls in `Barrier::barrier()`. If the page was unmapped between those calls,
-                // they would not have the expected effect of generating IPI.
                 libc::mlock(page, page_size as libc::size_t);
 
-                // Initialize the mutex.
                 let lock = UnsafeCell::new(libc::PTHREAD_MUTEX_INITIALIZER);
                 let mut attr = mem::MaybeUninit::<libc::pthread_mutexattr_t>::uninit();
                 fatal_assert!(libc::pthread_mutexattr_init(attr.as_mut_ptr()) == 0);

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -103,16 +103,17 @@ pub(crate) fn direct_io_ify(fd: RawFd, flags: libc::c_int) -> io::Result<()> {
     Ok(())
 }
 
-// This essentially converts the nix errors into something we can integrate with
-// the rest of the crate.
+/// This essentially converts the nix errors into something we can integrate with
+/// the rest of the crate.
+///
+/// Unnamed unix sockets have a len of 0. Technically we should make sure this
+/// has family = `AF_UNIX`, but if len == 0 the OS may not have written
+/// anything here. If this is not supposed to be unix, the upper layers will
+/// complain.
 pub(crate) unsafe fn ssptr_to_sockaddr<T: SockaddrLike>(
     ss: MaybeUninit<nix::sys::socket::sockaddr_storage>,
     len: usize,
 ) -> io::Result<T> {
-    // Unnamed unix sockets have a len of 0. Technically we should make sure this
-    // has family = AF_UNIX, but if len == 0 the OS may not have written
-    // anything here. If this is not supposed to be unix, the upper layers will
-    // complain.
     if len == 0 {
         let addr = nix::sys::socket::UnixAddr::new("").unwrap();
         Ok(T::from_raw(addr.as_ptr() as *const _, Some(addr.len())).unwrap())
@@ -186,13 +187,13 @@ use std::{convert::TryFrom, ops::Deref, sync::atomic::AtomicBool};
 #[derive(Debug, Default)]
 pub(crate) struct ReactorGlobalState {
     idgen: usize,
-    // reactor_id -> notifier
+    /// `reactor_id` -> notifier
     sleep_notifiers: AHashMap<usize, std::sync::Weak<SleepNotifier>>,
 }
 
 impl ReactorGlobalState {
+    /// Note how the id starts from 1. 0 means "no notifier present"
     fn new_local_state(&mut self) -> io::Result<Arc<SleepNotifier>> {
-        // Note how this starts from 1. 0 means "no notifier present"
         self.idgen += 1;
         let id = self.idgen;
         if id == 0 || id == usize::MAX {
@@ -316,10 +317,12 @@ impl SleepNotifier {
         }
     }
 
+    /// Queues a waker, and notifies the destination executor.
+    ///
+    /// The sender only errors out if the destination disconnected. That
+    /// most likely happened because the remote executor already died, in which
+    /// case they were no longer interested in this notification. But log.
     pub(crate) fn queue_waker(&self, waker: Waker, force_notify: bool) {
-        // Sender only errors out if the destination disconnected. That
-        // most likely happened because the remote executor already died, in which
-        // case they were no longer interested in this notification. But log.
         if self.waker_sender.send(waker).is_err() {
             debug!(
                 "Executor {} cannot send the waker to its destination!",
@@ -339,9 +342,9 @@ impl SleepNotifier {
         processed
     }
 
+    /// This will allow this `eventfd` to be notified. This should not happen
+    /// for the placeholder (disconnected) case.
     pub(super) fn prepare_to_sleep(&self) {
-        // This will allow this `eventfd` to be notified. This should not happen
-        // for the placeholder (disconnected) case.
         assert_ne!(self.id, usize::MAX);
         self.should_notify.store(true, Ordering::Relaxed);
     }
@@ -352,11 +355,11 @@ impl SleepNotifier {
 }
 
 impl Drop for SleepNotifier {
+    /// The other side may still be holding a reference in which case the notifier
+    /// will be freed later. However, we can't receive notifications anymore
+    /// so memory must be zeroed here.
     fn drop(&mut self) {
         let mut state = REACTOR_GLOBAL_STATE.write().unwrap();
-        // The other side may still be holding a reference in which case the notifier
-        // will be freed later. However, we can't receive notifications anymore
-        // so memory must be zeroed here.
         self.wake_up();
         state.sleep_notifiers.remove(&self.id).unwrap();
     }
@@ -419,15 +422,15 @@ pub(crate) enum DirectIo {
 /// meaning we can't conflate Pollable and the buffer type.
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum PollableStatus {
-    // The pollable ring only supports Direct I/O, so always true.
+    /// The pollable ring only supports Direct I/O, so always true.
     Pollable,
-    // Non-pollable can go either way
+    /// Non-pollable can go either way
     NonPollable(DirectIo),
 }
 
-// code imported from libc crate
-// libc::statx isn't used because it's not available when targeting musl
-
+/// Code imported from libc crate.
+///
+/// `libc::statx` isn't used because it's not available when targeting musl
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub struct Statx {
@@ -508,8 +511,8 @@ pub(crate) struct KernelTimespec {
     pub tv_nsec: i64,
 }
 
-// `io-uring` is a separate crate, so hold it to that layout here: a change
-// there would otherwise show up as a timeout of garbage duration.
+/// `io-uring` is a separate crate, so hold it to that layout here: a change
+/// there would otherwise show up as a timeout of garbage duration.
 const _: () = {
     assert!(
         std::mem::size_of::<KernelTimespec>() == std::mem::size_of::<io_uring::types::Timespec>()
@@ -653,16 +656,15 @@ impl Wakers {
 
 /// Shuts down the requested side of a socket.
 ///
-/// If this source is not a socket, the `shutdown()` syscall error is ignored.
+/// This may not be a TCP stream, but that's okay: all we do is call
+/// `shutdown()` on the raw descriptor. The only actual error may be
+/// `ENOTCONN`; ignore everything else.
 pub(crate) fn shutdown(raw: RawFd, how: Shutdown) -> io::Result<()> {
-    // This may not be a TCP stream, but that's okay. All we do is call `shutdown()`
-    // on the raw descriptor and ignore errors if it's not a socket.
     let res = unsafe {
         let stream = ManuallyDrop::new(TcpStream::from_raw_fd(raw));
         stream.shutdown(how)
     };
 
-    // The only actual error may be ENOTCONN, ignore everything else.
     match res {
         Err(err) if err.kind() == io::ErrorKind::NotConnected => Err(err),
         _ => Ok(()),

--- a/glommio/src/sys/source.rs
+++ b/glommio/src/sys/source.rs
@@ -27,8 +27,9 @@ use std::{
 };
 
 #[derive(Debug)]
-#[allow(dead_code)] // Clippy is unhappy with some of the fields on these enums never being read,
-                    // but they are certainly used, and read by debug
+/// Clippy is unhappy with some of the fields on these enums never being read,
+/// but they are certainly used, and read by debug
+#[allow(dead_code)]
 pub(crate) enum SourceType {
     Write(PollableStatus, IoBuffer),
     Read(PollableStatus, Option<IoBuffer>),
@@ -224,6 +225,9 @@ impl Source {
         })
     }
 
+    /// Returns the result of this I/O source, if it has completed.
+    ///
+    /// If a scheduler latency collection function is present, invoke it once.
     pub(crate) fn result(&self) -> Option<io::Result<usize>> {
         let mut inner = self.inner.borrow_mut();
         let ret = inner
@@ -235,7 +239,6 @@ impl Source {
             return ret;
         }
 
-        // if there is a scheduler latency collection function present, invoke it once
         if let Some(Some(stat_fn)) = inner.stats_collection.as_ref().map(|x| x.latency) {
             if let Some(lat) = inner.wakers.timestamps() {
                 drop(inner);
@@ -264,9 +267,9 @@ impl Source {
         ret
     }
 
-    // adds a single waiter to the list, replacing any waiter that may already
-    // exist. Should be used for single streams that map a future 1:1 to their I/O
-    // source
+    /// Adds a single waiter to the list, replacing any waiter that may already
+    /// exist. Should be used for single streams that map a future 1:1 to their I/O
+    /// source
     pub(crate) fn add_waiter_single(&self, waker: &Waker) {
         let mut inner = self.inner.borrow_mut();
         let waiters = &mut inner.wakers.waiters;
@@ -281,8 +284,8 @@ impl Source {
         debug_assert_eq!(inner.wakers.waiters.len(), 1)
     }
 
-    // adds a waiter to the list. Useful for streams that have many futures waiting
-    // on a single I/O source
+    /// Adds a waiter to the list. Useful for streams that have many futures waiting
+    /// on a single I/O source
     pub(crate) fn add_waiter_many(&self, waker: Waker) {
         self.inner.borrow_mut().wakers.waiters.push(waker)
     }
@@ -317,28 +320,28 @@ impl Source {
 }
 
 impl Drop for Source {
+    /// Drops the source and consumes its enqueue status:
+    ///
+    /// * If it was never submitted (`Enqueued`), it is safe to consume the source
+    ///   here -- the kernel didn't see our buffers. Consuming the source signals
+    ///   to the submit method that we are no longer interested in submitting
+    ///   this. This should be cheaper than removing elements from the vector all
+    ///   the time.
+    /// * If it was dispatched (`Dispatched`) but is being cancelled, the kernel
+    ///   might be using the buffers right now, so `consume_source` is delayed
+    ///   until the corresponding event is consumed from the completion queue.
+    ///   Marking it `Canceled` is not necessary, but useful for correctness.
     fn drop(&mut self) {
         let mut inner = self.inner.borrow_mut();
         let enqueued = inner.enqueued.as_mut();
         if let Some(EnqueuedSource { id, queue, status }) = enqueued {
             match status {
                 EnqueuedStatus::Enqueued => {
-                    // We never submitted the request, so it's safe to consume
-                    // source here -- kernel didn't see our buffers. By consuming
-                    // the source we are signaling to the submit method that we are
-                    // no longer interested in submitting this. This should be cheaper
-                    // than removing elements from the vector all the time.
-
                     *status = EnqueuedStatus::Canceled;
                 }
                 EnqueuedStatus::Dispatched => {
-                    // We are cancelling this request, but it is already submitted.
-                    // This means that the kernel might be using the buffers right
-                    // now, so we delay `consume_source` until we consume the
-                    // corresponding event from the completion queue.
-
                     queue.borrow_mut().cancel_request(*id);
-                    *status = EnqueuedStatus::Canceled; // not necessary, but useful for correctness
+                    *status = EnqueuedStatus::Canceled;
                 }
                 EnqueuedStatus::Canceled => unreachable!(),
             }

--- a/glommio/src/sys/sysfs.rs
+++ b/glommio/src/sys/sysfs.rs
@@ -111,8 +111,16 @@ impl BlockDevice {
         }
     }
 
+    /// Creates a `BlockDevice` from a `(major, minor)` device id, reading the
+    /// kernel's sysfs data for it.
+    ///
+    /// Prefers `/sys/dev/block/major:minor`, then resolves it. If we can't find
+    /// the queue, it is treated as non-pollable and conservative defaults are
+    /// returned (but kept as "not memory"). `rotational` should exist for real
+    /// block queues, but we don't hard-fail. `io_poll` may not exist on older
+    /// kernels/drivers; treat missing as false. `write_cache` might be missing
+    /// on some virtual devices; default to write back.
     fn new(dev_id: (usize, usize)) -> BlockDevice {
-        // Prefer /sys/dev/block/major:minor, then resolve it.
         let link = PathBuf::from(format!("/sys/dev/block/{}:{}", dev_id.0, dev_id.1));
 
         let dir = match link.canonicalize() {
@@ -121,12 +129,9 @@ impl BlockDevice {
             Err(e) => panic!("Unexpected error canonicalizing {}: {e:?}", link.display()),
         };
 
-        // Find the correct queue directory (partition-safe).
         let queue = match find_queue_dir(dir.clone()) {
             Some(q) => q,
             None => {
-                // If we can’t find queue, treat it as non-pollable and return conservative defaults.
-                // (But keep it as "not memory".)
                 return BlockDevice {
                     memory_device: false,
                     rotational: true,
@@ -143,10 +148,8 @@ impl BlockDevice {
             }
         };
 
-        // Rotational should exist for real block queues, but don’t hard-fail.
         let rotational = read_int_opt(&queue.join("rotational")).unwrap_or(1) != 0;
 
-        // io_poll may not exist on older kernels/drivers; treat missing as false.
         let io_poll = read_int_opt(&queue.join("io_poll")).unwrap_or(0) != 0;
 
         let minimum_io_size = read_int_opt(&queue.join("minimum_io_size")).unwrap_or(512) as usize;
@@ -161,7 +164,6 @@ impl BlockDevice {
         let max_segment_size = read_int_opt(&queue.join("max_segment_size"))
             .unwrap_or((u32::MAX - 1) as isize) as usize;
 
-        // write_cache might be missing on some virtual devices; default to write back.
         let cache = read_to_string(queue.join("write_cache"))
             .ok()
             .and_then(|s| s.parse::<StorageCache>().ok())
@@ -298,16 +300,16 @@ impl ListIterator {
             .map_err(|_| self.err_invalid())
     }
 
+    /// Leaves a list terminating `'\n'` for syntax verification. The white
+    /// spaces that are skipped are defined in:
+    /// <https://github.com/torvalds/linux/blob/d93a0d43e3d0ba9e19387be4dae4a8d5b175a8d7/include/linux/ctype.h#L17-L33>
+    /// <https://github.com/torvalds/linux/blob/d93a0d43e3d0ba9e19387be4dae4a8d5b175a8d7/lib/ctype.c#L12-L36>
     fn skip_delim(&mut self) {
         fn is_space(c: char) -> bool {
-            // White spaces are defined in:
-            // https://github.com/torvalds/linux/blob/d93a0d43e3d0ba9e19387be4dae4a8d5b175a8d7/include/linux/ctype.h#L17-L33
-            // https://github.com/torvalds/linux/blob/d93a0d43e3d0ba9e19387be4dae4a8d5b175a8d7/lib/ctype.c#L12-L36
             let c = c as u8;
             (9..=13).contains(&c) || c == 32 || c == 160
         }
 
-        // leave a list terminating '\n' for syntax verification
         let idx_max = if self.idx < self.list_str.len() {
             self.list_str.len() - 1
         } else {
@@ -385,8 +387,8 @@ impl ListIterator {
         io::Error::new(io::ErrorKind::InvalidData, msg)
     }
 
-    // Returns the first error if any elements were errors, otherwise returns the
-    // collection of unwrapped elements
+    /// Returns the first error if any elements were errors, otherwise returns the
+    /// collection of unwrapped elements
     #[cfg(test)]
     fn collect_ok<C>(self) -> io::Result<C>
     where
@@ -481,6 +483,8 @@ impl RangeIter<Unchecked> {
 }
 
 impl RangeIter<Checked> {
+    /// At the point of the group-stride check below:
+    /// `0 < self.used_size <= self.group_size`
     fn next(&mut self) -> Option<usize> {
         if self.used_size == 0 {
             return None;
@@ -491,7 +495,6 @@ impl RangeIter<Checked> {
             None => return self.ret(self.beg),
         };
 
-        // at this point: 0 < self.used_size <= self.group_size
         if (last - self.beg) % self.group_size < self.used_size - 1 {
             self.ret(last.checked_add(1)?)
         } else {
@@ -553,6 +556,9 @@ pub(super) mod test_helpers {
             })
         }
 
+        /// Pops the next set bit. The subtraction below cannot underflow:
+        /// `self.n_bits_on_deck` == 0 implies `self.bits_on_deck` == 0, which
+        /// would take the branch above
         fn next(&mut self) -> Option<usize> {
             loop {
                 match self.bits_on_deck {
@@ -561,8 +567,6 @@ pub(super) mod test_helpers {
                     }
                     Some(ref mut m) => {
                         let is_set = (*m & 1) != 0;
-                        // `self.n_bits_on_deck` == 0 implies `self.bits_on_deck` == 0, which
-                        // would take the branch above, so this cannot underflow
                         self.n_bits_on_deck -= 1;
                         self.bit_counter += 1;
                         *m >>= 1;
@@ -574,8 +578,11 @@ pub(super) mod test_helpers {
             }
         }
 
+        /// Puts the next hexadecimal run on deck. Counts unused bits (these are
+        /// all equal to 0). Each hexadecimal char represents 4 bits and we only
+        /// have space for 64 bits. `sub_str` should only contain hexadecimal
+        /// values at this point, and `sub_str` could represent less than 64 bits
         fn set_on_deck(&mut self) -> Option<u64> {
-            // Count unused bits (these are all equal to 0)
             self.bit_counter += self.n_bits_on_deck;
 
             self.s_end = 1 + self
@@ -588,15 +595,12 @@ pub(super) mod test_helpers {
                 .rfind(|c: char| !c.is_ascii_hexdigit())
                 .map_or(0, |ii| ii + 1);
 
-            // Each hexadecimal char represents 4 bits and we only have space for 64 bits
             if self.s_end - self.s_beg > 16 {
                 self.s_beg = self.s_end - 16;
             }
 
             let sub_str = self.hex_str.get(self.s_beg..self.s_end)?;
-            // `sub_str` should only contain hexadecimal values at this point
             self.bits_on_deck = Some(u64::from_str_radix(sub_str, 16).expect("not a hex value"));
-            // `sub_str` could represent less than 64 bits
             self.n_bits_on_deck = 4 * sub_str.len();
             self.bits_on_deck
         }

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -337,10 +337,11 @@ fn is_transient(err: &UringUnsupported) -> bool {
 ///
 /// Cached once per process, but only a definitive answer: a probe that failed
 /// for want of a descriptor is tried again.
+///
+/// A poisoned lock here carries no state worth protecting: the value behind
+/// it is a cached verdict, and a panicking prober leaves it untouched.
 pub(crate) fn check_uring_support() -> io::Result<()> {
     let unsupported = |reason: String| io::Error::new(io::ErrorKind::Unsupported, reason);
-    // A poisoned lock here carries no state worth protecting: the value behind
-    // it is a cached verdict, and a panicking prober leaves it untouched.
     let mut cached = IO_URING_SUPPORT
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -365,6 +366,17 @@ pub(crate) fn check_uring_support() -> io::Result<()> {
 }
 
 /// Builds the submission queue entry for one descriptor.
+///
+/// # Safety
+///
+/// Every pointer passed to the opcodes below belongs to a `Source` that the
+/// `SourceMap` keeps alive until the completion is reaped.
+///
+/// # Notes
+///
+/// * For `LinkTimeout`, the timespec is borrowed, not copied: it has to
+///   outlive the SQE. Same layout as `__kernel_timespec`, asserted in
+///   `sys/mod.rs`.
 fn fill_sqe<F>(
     op: &UringDescriptor,
     buffer_allocation: F,
@@ -376,8 +388,6 @@ where
     let mut user_data = op.user_data;
     let fd = types::Fd(op.fd);
 
-    // SAFETY: every pointer below belongs to a `Source` that the `SourceMap`
-    // keeps alive until the completion is reaped.
     let entry = unsafe {
         match op.args {
             UringOpDescriptor::PollAdd(events) => {
@@ -407,10 +417,13 @@ where
                             let entry = opcode::Read::new(fd, buf.as_mut_ptr(), len as u32)
                                 .offset(pos)
                                 .build();
-                            // If you have a buffer here, that very likely means you are reusing the
-                            // source. The kernel knows about that buffer already, and will write to
-                            // it. So this can only be called if there is no buffer attached to it.
-                            assert!(slot.is_none());
+                            assert!(
+                                slot.is_none(),
+                                "if you have a buffer here, that very likely means you are \
+                                 reusing the source; the kernel knows about that buffer \
+                                 already, and will write to it, so this can only be called \
+                                 if there is no buffer attached to it"
+                            );
                             *slot = Some(IoBuffer::DmaSink(buf));
                             entry
                         }
@@ -431,8 +444,6 @@ where
                 opcode::Connect::new(fd, (*addr).as_ptr(), (*addr).len()).build()
             }
             UringOpDescriptor::LinkTimeout(timespec) => {
-                // Borrowed, not copied: it has to outlive the SQE. Same
-                // layout as `__kernel_timespec`, asserted in `sys/mod.rs`.
                 opcode::LinkTimeout::new(timespec as *const types::Timespec).build()
             }
             UringOpDescriptor::Accept(addr) => {
@@ -447,8 +458,8 @@ where
                 .build(),
             UringOpDescriptor::StatxFd(statx_fd, statx_buf) => {
                 const EMPTY_PATH: &[u8] = b"\0";
-                // Not defined by the libc crate for musl targets. 0 in the
-                // kernel UAPI (`linux/stat.h`): do whatever stat() does.
+                /// Not defined by the libc crate for musl targets. 0 in the
+                /// kernel UAPI (`linux/stat.h`): do whatever stat() does.
                 const AT_STATX_SYNC_AS_STAT: libc::c_int = 0;
                 let flags = AT_STATX_SYNC_AS_STAT | libc::AT_NO_AUTOMOUNT | libc::AT_EMPTY_PATH;
                 opcode::Statx::new(
@@ -562,15 +573,16 @@ where
 
 /// Turns a raw CQE result into an `io::Result`. io_uring reports failure as a
 /// negative errno in the completion, not through errno.
+///
+/// `ECANCELED` is converted to `ETIMEDOUT`. This will be the case for linked
+/// `sqe`s with a timeout, and if we wanted to be really strict we'd check. But
+/// if the operation is truly cancelled no one will check the result, and we
+/// have no other use case for cancel at the moment so keep it simple
 fn transmute_error(res: i32) -> io::Result<usize> {
     if res >= 0 {
         return Ok(res as usize);
     }
     Err(io::Error::from_raw_os_error(-res)).map_err(|x: io::Error| {
-        // Convert CANCELED to TimedOut. This will be the case for linked `sqe`s with a
-        // timeout, and if we wanted to be really strict we'd check. But if
-        // the operation is truly cancelled no one will check the result,
-        // and we have no other use case for cancel at the moment so keep it simple
         if let Some(libc::ECANCELED) = x.raw_os_error() {
             io::Error::from_raw_os_error(libc::ETIMEDOUT)
         } else {
@@ -607,8 +619,8 @@ fn record_stats<Ring: UringCommon>(
     }
 }
 
-// Find the next complete chain of events from the queue.
-// Returns None if the queue is empty.
+/// Find the next complete chain of events from the queue.
+/// Returns None if the queue is empty.
 fn peek_one_chain(queue: &VecDeque<UringDescriptor>, ring_size: usize) -> Option<Range<usize>> {
     if queue.is_empty() {
         return None;
@@ -624,8 +636,8 @@ fn peek_one_chain(queue: &VecDeque<UringDescriptor>, ring_size: usize) -> Option
     Some(0..chain + 1)
 }
 
-// Extract a chain of events from the queue.
-// The chain be empty if the sources were cancelled
+/// Extract a chain of events from the queue.
+/// The chain be empty if the sources were cancelled
 fn extract_one_chain(
     source_map: &mut SourceMap,
     queue: &mut VecDeque<UringDescriptor>,
@@ -659,7 +671,15 @@ fn extract_one_chain(
         .collect()
 }
 
-// Submit the next complete chain of events from the queue if available.
+/// Submit the next complete chain of events from the queue if available.
+///
+/// A linked chain is only meaningful whole -- half of one is a link timeout
+/// with no operation to guard. Bails if it doesn't fit and lets the caller
+/// flush first.
+///
+/// The `sq.push` inside the unsafe block is sound because `op`'s buffers
+/// belong to sources the `SourceMap` keeps alive until the completion is
+/// reaped, and the capacity check above means the push cannot fail.
 fn submit_event_chain(
     source_map: &mut SourceMap,
     ring: &mut IoUring,
@@ -670,9 +690,6 @@ fn submit_event_chain(
     let now = Instant::now();
 
     while let Some(chain) = peek_one_chain(queue, ring_size) {
-        // A linked chain is only meaningful whole -- half of one is a link
-        // timeout with no operation to guard. Bail if it doesn't fit and let
-        // the caller flush first.
         let mut sq = ring.submission();
         if sq.capacity() - sq.len() < chain.len() {
             return None;
@@ -680,16 +697,12 @@ fn submit_event_chain(
 
         let ops = extract_one_chain(source_map, queue, chain, now);
         if ops.is_empty() {
-            // all the sources in the ring were cancelled
             continue;
         }
 
         for op in ops {
             let allocator = allocator.clone();
             let entry = fill_sqe(&op, move |size| allocator.new_buffer(size), source_map);
-            // SAFETY: `op`'s buffers belong to sources the `SourceMap` keeps
-            // alive until the completion is reaped, and the check above means
-            // the push cannot fail.
             unsafe {
                 sq.push(&entry)
                     .expect("chain was checked to fit in the submission queue");
@@ -700,6 +713,9 @@ fn submit_event_chain(
     Some(false)
 }
 
+/// Processes a single completion event, if any.
+///
+/// No user data is `POLL_REMOVE` or `CANCEL`; we won't process it.
 fn process_one_event<F, R>(
     cqe: Option<cqueue::Entry>,
     try_process: F,
@@ -711,7 +727,6 @@ where
     R: FnOnce(RefMut<'_, InnerSource>, io::Result<usize>) -> io::Result<usize>,
 {
     if let Some(value) = cqe {
-        // No user data is `POLL_REMOVE` or `CANCEL`, we won't process.
         if value.user_data() == 0 {
             return Some(false);
         }
@@ -969,10 +984,10 @@ impl UringCommon for PollRing {
         self.ring.submitter()
     }
 
+    /// We need to enter the kernel to submit and collect CQEs so if the number
+    /// of submitted requests doesn't match the number of request we collected,
+    /// we need to poll.
     fn needs_kernel_enter(&mut self) -> bool {
-        // We need to enter the kernel to submit and collect CQEs so if the number of
-        // submitted requests doesn't match the number of request we collected, we need
-        // to poll.
         self.in_kernel > 0 || self.waiting_kernel_submission() > 0
     }
 
@@ -1002,10 +1017,10 @@ impl UringCommon for PollRing {
         Ok(x)
     }
 
+    /// Reaps the completion before the closure below borrows `self`, since
+    /// the completion queue borrows the ring exclusively.
     fn consume_one_event(&mut self) -> Option<bool> {
         let source_map = self.source_map.clone();
-        // Reap the completion before the closure below borrows `self`, since
-        // the completion queue borrows the ring exclusively.
         let cqe = self.ring.completion().next();
         process_one_event(
             cqe,
@@ -1147,10 +1162,14 @@ impl SleepableRing {
         timer_source
     }
 
+    /// Now must wait on the `eventfd` in case someone wants to wake us up.
+    /// If we can't then we can't sleep and will just bail immediately.
+    ///
+    /// The read targets the eventfd source's own buffer, which the
+    /// `SourceMap` keeps alive until the completion is reaped. The
+    /// `is_full()` check above means the push cannot fail.
     fn install_eventfd(&mut self, eventfd_src: &Source) -> bool {
         if !self.ring.submission().is_full() {
-            // Now must wait on the `eventfd` in case someone wants to wake us up.
-            // If we can't then we can't sleep and will just bail immediately
             let op = UringDescriptor {
                 fd: eventfd_src.raw(),
                 flags: squeue::Flags::empty(),
@@ -1179,9 +1198,6 @@ impl SleepableRing {
                 },
                 &mut self.source_map.borrow_mut(),
             );
-            // SAFETY: the read targets the eventfd source's own buffer, which
-            // the `SourceMap` keeps alive until the completion is reaped. The
-            // emptiness check above means the push cannot fail.
             unsafe {
                 self.ring
                     .submission()
@@ -1201,6 +1217,26 @@ impl SleepableRing {
         }
     }
 
+    /// Sleeps until an event arrives, by preparing an SQE that polls the link
+    /// source and links the two rings.
+    ///
+    /// We have now prepared the SQE that links the two rings; we need to
+    /// submit it successfully to be able to safely sleep. If we fail to
+    /// submit the `SQE` that links the rings, we can't sleep: waiting here is
+    /// unsafe because we could end up waiting much longer than needed.
+    ///
+    /// The entry stays queued. io-uring can't rewrite a pushed entry and
+    /// doesn't need to: it goes out with the next submit and its completion
+    /// retires the source. Wakes nobody, costs a spurious CQE.
+    ///
+    /// On success the rings are linked. Goodnight!
+    ///
+    /// Can't link rings because we ran out of `CQE`s? Just can't sleep.
+    /// Submit what we have; once we're out of here we'll consume them and at
+    /// some point will be able to sleep again.
+    ///
+    /// The poll targets the latency ring's fd, which outlives this reactor,
+    /// and the `is_full()` check above means the push cannot fail.
     fn sleep(&mut self, link: &Source) -> io::Result<usize> {
         assert_eq!(
             self.waiting_kernel_submission(),
@@ -1219,17 +1255,12 @@ impl SleepableRing {
                 args: UringOpDescriptor::PollAdd(common_flags() | read_flags()),
             };
             let entry = fill_sqe(&op, DmaBuffer::new, &mut self.source_map.borrow_mut());
-            // SAFETY: the poll targets the latency ring's fd, which outlives
-            // this reactor, and the check above means the push cannot fail.
             unsafe {
                 self.ring
                     .submission()
                     .push(&entry)
                     .expect("submission queue was checked to have room");
             }
-
-            // We have now prepared the SQE that links the two rings. We now need to submit
-            // it successfully to be able to safely sleep.
 
             if self
                 .submit_sqes()
@@ -1238,17 +1269,8 @@ impl SleepableRing {
                 .or_else(Reactor::intr_ok)?
                 != 1
             {
-                // We failed to submit the `SQE` that links the rings. Just can't sleep.
-                // Waiting here is unsafe because we could end up waiting much longer than
-                // needed.
-                //
-                // The entry stays queued. io-uring can't rewrite a pushed
-                // entry and doesn't need to: it goes out with the next submit
-                // and its completion retires the source. Wakes nobody, costs a
-                // spurious CQE.
                 Err(io::Error::from_raw_os_error(libc::EBUSY))
             } else {
-                // The rings are linked. Goodnight!
                 self.ring
                     .submit_and_wait(1)
                     .map(|_| 1)
@@ -1257,9 +1279,6 @@ impl SleepableRing {
                     .or_else(Reactor::intr_ok)
             }
         } else {
-            // Can't link rings because we ran out of `CQE`s. Just can't sleep.
-            // Submit what we have, once we're out of here we'll consume them
-            // and at some point will be able to sleep again.
             self.submit_sqes()
                 .or_else(Reactor::busy_ok)
                 .or_else(Reactor::again_ok)
@@ -1289,9 +1308,9 @@ impl UringCommon for SleepableRing {
         false
     }
 
+    /// We only need to enter the kernel to submit SQEs, not to collect CQEs
+    /// (the kernel posts the CQEs asynchronously for us)
     fn needs_kernel_enter(&mut self) -> bool {
-        // We only need to enter the kernel to submit SQEs, not to collect CQEs (the
-        // kernel posts the CQEs asynchronously for us)
         self.waiting_kernel_submission() > 0
     }
 
@@ -1323,9 +1342,9 @@ impl UringCommon for SleepableRing {
         Ok(x)
     }
 
+    /// As above: reap first, then borrow `self` in the post-process closure.
     fn consume_one_event(&mut self) -> Option<bool> {
         let source_map = self.source_map.clone();
-        // As above: reap first, then borrow `self` in the post-process closure.
         let cqe = self.ring.completion().next();
         process_one_event(
             cqe,
@@ -1359,7 +1378,7 @@ impl UringCommon for SleepableRing {
 }
 
 pub(crate) struct Reactor {
-    // FIXME: it is starting to feel we should clean this up to a Inner pattern
+    /// FIXME: it is starting to feel we should clean this up to a Inner pattern
     main_ring: RefCell<SleepableRing>,
     latency_ring: RefCell<SleepableRing>,
     poll_ring: RefCell<PollRing>,
@@ -1369,12 +1388,12 @@ pub(crate) struct Reactor {
 
     link_fd: RawFd,
 
-    // This keeps the `eventfd` alive. Drop will close it when we're done
+    /// This keeps the `eventfd` alive. Drop will close it when we're done
     notifier: Arc<sys::SleepNotifier>,
-    // This is the source used to handle the notifications into the ring.
-    // It is reused, unlike the timeout src, because it is possible and likely
-    // that it will be in the ring through many calls to the reactor loop. It only ever gets
-    // completed if this reactor is woken up from another one
+    /// This is the source used to handle the notifications into the ring.
+    /// It is reused, unlike the timeout src, because it is possible and likely
+    /// that it will be in the ring through many calls to the reactor loop. It only ever gets
+    /// completed if this reactor is woken up from another one
     eventfd_src: Source,
     source_map: Rc<RefCell<SourceMap>>,
 
@@ -1427,6 +1446,12 @@ fn align_up(v: usize, align: usize) -> usize {
 }
 
 impl Reactor {
+    /// Creates a new reactor.
+    ///
+    /// Always have at least some small amount of memory for the slab. The
+    /// `register_buffers` calls are sound because `registry` borrows the
+    /// allocator's arena, which lives as long as the reactor and therefore
+    /// outlives the registration.
     pub(crate) fn new(
         notifier: Arc<sys::SleepNotifier>,
         mut io_memory: usize,
@@ -1443,7 +1468,6 @@ impl Reactor {
         }
 
         let source_map = Rc::new(RefCell::new(SourceMap::default()));
-        // always have at least some small amount of memory for the slab
         io_memory = std::cmp::max(align_up(io_memory, 4096), 65536);
 
         let allocator = Rc::new(UringBufferAllocator::new(io_memory));
@@ -1461,8 +1485,6 @@ impl Reactor {
         let mut latency_ring =
             SleepableRing::new(ring_depth, "latency", allocator.clone(), source_map.clone())?;
 
-        // SAFETY: `registry` borrows the allocator's arena, which lives as long as
-        // the reactor and therefore outlives the registration.
         match unsafe { main_ring.submitter().register_buffers(&registry) } {
             Err(x) => warn!("Error: registering buffers in the main ring. Skipping{x:#?}"),
             Ok(_) => match unsafe { poll_ring.submitter().register_buffers(&registry) } {
@@ -1944,6 +1966,48 @@ impl Reactor {
     ///   to the point where we *leave* this method. For instance: if we spin
     ///   here for 3ms and the preempt timer is 10ms that would leave the next
     ///   task queue just 7ms to run.
+    ///
+    /// The steps, in order:
+    ///
+    /// * Consume all events from the rings.
+    /// * Cancel the old timer regardless of whether we can sleep: if we
+    ///   won't sleep, we will register the new timer with its new value. But
+    ///   if we will sleep, there might be a timer registered that needs to
+    ///   be removed otherwise we'll wake up when it expires.
+    /// * Schedule the throughput-based timeout immediately: it won't matter
+    ///   if we end up sleeping.
+    /// * Flush cancellations. This will only dispatch if we run out of sqes.
+    ///   Which means until `flush_rings!` nothing is really send to the
+    ///   kernel... which happens right here. If you ever reorder this code
+    ///   just be careful about this dependency.
+    /// * Pick up the results of any cancellations.
+    /// * If we generated any event so far, we can't sleep. Need to handle
+    ///   them.
+    ///
+    /// When sleeping:
+    ///
+    /// * It's ok to sleep, but if there is a timer set, we need to make sure
+    ///   we wake up to handle it.
+    /// * From this moment on the remote executors are aware that we are
+    ///   sleeping. We have to sweep the remote channels function once more
+    ///   because since last time until now it could be that something
+    ///   happened in a remote executor that opened up room. If it did we
+    ///   bail on sleep and go process it.
+    /// * `membarrier::heavy()` -- see
+    ///   <https://www.scylladb.com/2018/02/15/memory-barriers-seastar-linux/>
+    ///   for details. This translates to `sys_membarrier()` /
+    ///   `MEMBARRIER_CMD_PRIVATE_EXPEDITED`.
+    /// * May have new cancellations related to the link ring fd; flush them.
+    /// * Woke up, so no need to notify us anymore.
+    ///
+    /// # A note about `need_preempt`
+    ///
+    /// If in the last call to `consume_rings!` some events completed, the
+    /// tail and head would have moved to match. So it does not matter that
+    /// events were generated after we registered the timer: since we
+    /// consumed them here, `need_preempt()` should be false at this point.
+    /// As soon as the next event in the preempt ring completes, though, then
+    /// it will be true.
     pub(crate) fn wait<Preempt, F>(
         &self,
         preempt_timer: Preempt,
@@ -1961,19 +2025,10 @@ impl Reactor {
         let mut main_ring = self.main_ring.borrow_mut();
         let mut lat_ring = self.latency_ring.borrow_mut();
 
-        // consume all events from the rings
         consume_rings!(into &mut woke; lat_ring, poll_ring, main_ring);
 
-        // Cancel the old timer regardless of whether we can sleep:
-        // if we won't sleep, we will register the new timer with its new
-        // value.
-        //
-        // But if we will sleep, there might be a timer registered that needs
-        // to be removed otherwise we'll wake up when it expires.
         drop(self.latency_preemption_timeout_src.take());
 
-        // Schedule the throughput-based timeout immediately: it won't matter if we end
-        // up sleeping.
         self.throughput_preemption_timeout_src.replace(Some(
             main_ring.prepare_throughput_preemption_timer(
                 self.ring_depth() as u32,
@@ -1981,16 +2036,10 @@ impl Reactor {
             ),
         ));
 
-        // This will only dispatch if we run out of sqes. Which means until
-        // flush_rings! nothing is really send to the kernel...
         flush_cancellations!(into &mut woke; lat_ring, poll_ring, main_ring);
-        // ... which happens right here. If you ever reorder this code just
-        // be careful about this dependency.
         flush_rings!(lat_ring, poll_ring, main_ring)?;
-        // pick up the results of any cancellations
         consume_rings!(into &mut woke; lat_ring, poll_ring, main_ring);
 
-        // If we generated any event so far, we can't sleep. Need to handle them.
         let should_sleep = preempt_timer().is_none()
             && (woke == 0)
             && poll_ring.can_sleep()
@@ -1998,33 +2047,22 @@ impl Reactor {
             && lat_ring.can_sleep();
 
         if should_sleep {
-            // We are about to go to sleep. It's ok to sleep, but if there
-            // is a timer set, we need to make sure we wake up to handle it.
             if let Some(dur) = user_timer {
                 self.latency_preemption_timeout_src
                     .set(Some(lat_ring.prepare_latency_preemption_timer(dur)));
                 assert!(flush_rings!(lat_ring)? > 0);
             }
-            // From this moment on the remote executors are aware that we are sleeping
-            // We have to sweep the remote channels function once more because since
-            // last time until now it could be that something happened in a remote executor
-            // that opened up room. If it did we bail on sleep and go process it.
             self.notifier.prepare_to_sleep();
-            // See https://www.scylladb.com/2018/02/15/memory-barriers-seastar-linux/ for
-            // details. This translates to `sys_membarrier()` /
-            // `MEMBARRIER_CMD_PRIVATE_EXPEDITED`
             membarrier::heavy();
             let events = process_remote_channels() + self.flush_syscall_thread();
             if events == 0 {
                 if self.eventfd_src.is_installed().unwrap() {
                     self.link_rings_and_sleep(&mut main_ring)
                         .expect("some error");
-                    // May have new cancellations related to the link ring fd.
                     flush_cancellations!(into &mut 0; lat_ring, poll_ring, main_ring);
                     flush_rings!(lat_ring, poll_ring, main_ring)?;
                     consume_rings!(into &mut 0; lat_ring, poll_ring, main_ring);
                 }
-                // Woke up, so no need to notify us anymore.
                 self.notifier.wake_up();
             }
         }
@@ -2035,13 +2073,6 @@ impl Reactor {
             flush_rings!(lat_ring, main_ring)?;
         }
 
-        // A Note about `need_preempt`:
-        //
-        // If in the last call to consume_rings! some events completed, the tail and
-        // head would have moved to match. So it does not matter that events were
-        // generated after we registered the timer: since we consumed them here,
-        // need_preempt() should be false at this point. As soon as the next event
-        // in the preempt ring completes, though, then it will be true.
         Ok(should_sleep)
     }
 
@@ -2049,19 +2080,20 @@ impl Reactor {
         self.blocking_thread.flush()
     }
 
+    /// The status must not outlive the ring, and the `Reactor` that stores it
+    /// owns this whole structure. Bound to a local first because the
+    /// `CompletionQueue` it comes from only borrows `lat_ring`.
     pub(crate) fn preempt_status(&self) -> CompletionStatus {
         let mut lat_ring = self.latency_ring.borrow_mut();
-        // SAFETY: the status must not outlive the ring, and the `Reactor` that
-        // stores it owns this whole structure. Bound to a local first because
-        // the `CompletionQueue` it comes from only borrows `lat_ring`.
         let status = unsafe { lat_ring.ring.completion().status() };
         status
     }
 
     /// RAII-truncate asynchronously files that required it, e.g. because of
     /// padded writes, but were not closed explicitly.
+    ///
+    /// Actually synchronous for now!
     pub(crate) fn async_truncate(&self, fd: RawFd, size: u64) {
-        // actually synchronous for now!
         let _ = sys::truncate_file(fd, size);
     }
 
@@ -2079,15 +2111,16 @@ impl Reactor {
         });
     }
 
+    /// Dispatch requests according to the following rules:
+    /// * Disk reads/writes go to the poll ring if possible, or the main ring
+    ///   otherwise;
+    /// * Network Rx and connect/accept go the latency ring;
+    /// * Every other request are dispatched to the main ring;
+    ///
+    /// We avoid putting requests that come in high numbers on the latency
+    /// ring because the more request we issue there, the less effective it
+    /// becomes.
     pub(crate) fn ring_for_source(&self, source: &Source) -> RefMut<'_, dyn UringCommon> {
-        // Dispatch requests according to the following rules:
-        // * Disk reads/writes go to the poll ring if possible, or the main ring
-        //   otherwise;
-        // * Network Rx and connect/accept go the latency ring;
-        // * Every other request are dispatched to the main ring;
-        // We avoid putting requests that come in high numbers on the latency ring
-        // because the more request we issue there, the less effective it becomes.
-
         match &*source.source_type() {
             SourceType::Read(p, _) | SourceType::Write(p, _) => match p {
                 PollableStatus::Pollable => self.poll_ring.borrow_mut(),
@@ -2188,11 +2221,11 @@ mod tests {
 
     use super::*;
 
+    /// The probe list is the only thing standing between an unsupported
+    /// kernel and an -EINVAL on a completion nobody is expecting, so it has
+    /// to name every opcode fill_sqe can build.
     #[test]
     fn probes_every_opcode_glommio_submits() {
-        // The probe list is the only thing standing between an unsupported
-        // kernel and an -EINVAL on a completion nobody is expecting, so it has
-        // to name every opcode fill_sqe can build.
         let submitted = [
             opcode::Nop::CODE,
             opcode::Fsync::CODE,
@@ -2245,6 +2278,7 @@ mod tests {
         assert!(err.contains(expected), "{err}");
     }
 
+    /// Dropping the in-flight `slow` timer mid-test cancels it.
     #[test]
     fn timeout_smoke_test() {
         let notifier = sys::new_sleep_notifier().unwrap();
@@ -2300,7 +2334,7 @@ mod tests {
         let elapsed_ms = start.elapsed().as_millis();
         assert!((50..100).contains(&elapsed_ms));
 
-        drop(slow); // Cancel this one.
+        drop(slow);
 
         reactor.wait(|| None, None, 0, || 0).unwrap();
         let elapsed_ms = start.elapsed().as_millis();
@@ -2328,10 +2362,10 @@ mod tests {
         unsafe { alloc::alloc::dealloc(data.as_ptr(), l) }
     }
 
+    /// The allocator fails with a single page, because it needs extra metadata
+    /// space
     #[test]
     fn allocator_exhaustion() {
-        // The allocator fails with a single page, because it needs extra metadata
-        // space
         let al = Rc::new(UringBufferAllocator::new(8192));
         al.activate_registered_buffers(1234);
         let x = al.new_buffer(4096).unwrap();
@@ -2347,20 +2381,19 @@ mod tests {
         drop(x);
         drop(y);
 
-        // memory is back, able to allocate again
         let x = al.new_buffer(4096).unwrap();
         match x.uring_buffer_id() {
             Some(x) => assert_eq!(x, 1234),
             None => unreachable!("Expected uring buffer"),
         }
         drop(x);
-        // Allocation for an object that is too big fails
         let x = al.new_buffer(40960).unwrap();
         if x.uring_buffer_id().is_some() {
             unreachable!("Expected non-uring buffer")
         }
     }
 
+    /// Enqueues three nops. The second is soft-linked to the third.
     #[test]
     fn sqe_link_chain() {
         let allocator = Rc::new(UringBufferAllocator::new(65536));
@@ -2369,7 +2402,6 @@ mod tests {
         let q = ring.submission_queue();
         let mut queue = q.borrow_mut();
 
-        // enqueue three nops. The second is soft-linked to the third
         for i in 0..3 {
             queue.submissions.push_back(UringDescriptor {
                 args: UringOpDescriptor::Nop,
@@ -2383,12 +2415,10 @@ mod tests {
             });
         }
 
-        // the first nop is unlinked, so we're only expecting one SQE
         ring.submit_one_event(&mut queue.submissions);
         assert_eq!(1, ring.submit_sqes().unwrap());
         assert_eq!(1, ring.consume_completion_queue(&mut 0));
 
-        // the following nops are linked, so we expect two submissions and completions
         ring.submit_one_event(&mut queue.submissions);
         assert_eq!(2, ring.submit_sqes().unwrap());
         assert_eq!(2, ring.consume_completion_queue(&mut 0));
@@ -2396,6 +2426,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "Unterminated SQE link chain")]
+    /// If the link chain points outside of the queue, we panic
     fn unterminated_sqe_link_chain() {
         let allocator = Rc::new(UringBufferAllocator::new(65536));
         let source_map = Rc::new(RefCell::new(SourceMap::default()));
@@ -2410,12 +2441,12 @@ mod tests {
             user_data: 0,
         });
 
-        // If the link chain points outside of the queue, we panic
         ring.submit_one_event(&mut queue.submissions);
     }
 
     #[test]
     #[should_panic(expected = "Unterminated SQE link chain or submission queue overflow")]
+    /// If the link chain is longer than the io_uring submission queue, we panic
     fn sqe_link_chain_overflow() {
         let allocator = Rc::new(UringBufferAllocator::new(65536));
         let source_map = Rc::new(RefCell::new(SourceMap::default()));
@@ -2439,7 +2470,6 @@ mod tests {
             user_data: 0,
         });
 
-        // If the link chain is longer than the io_uring submission queue, we panic
         ring.submit_one_event(&mut queue.submissions);
     }
 }


### PR DESCRIPTION
### What does this PR do?

Second PR of the plain-comment cleanup series (#50 converted the license headers). It removes every plain `//` comment from `src/sys/` (282 at the start of the series): prose is hoisted into `///` doc comments on the enclosing item, restatements of adjacent code are deleted, and the six `// SAFETY:` comments in uring.rs become `# Safety` sections in the docs of `fill_sqe`, `submit_event_chain`, `install_eventfd`, `sleep`, `Reactor::new`, and `preempt_status`. The `need_preempt` essay and the dispatch-rules block now live in the `wait()` and `ring_for_source` docs; membarrier.rs keeps its third-party provenance note as an inner doc comment.

The pre-push baseline in `.githooks/pre-push` is lowered from 978 to 723 in the same commit, as the hook header instructs.

### Motivation

The CI `dylint` job runs warn-level until the per-module cleanup lands; `src/sys/` is the densest module (127 plain comments in uring.rs alone) and the safety annotations are the most valuable prose to normalize onto the `/// SAFETY:` precedent from dma_file.rs.

### Related issues

- Commit e278542 announced the series; #50 is PR 1/7.

### Additional Notes

Plain-comment warning count (cargo dylint): 978 → 723. Verified with `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features --locked`, `cargo test`, the CI doc gate, and the dylint count recipe from AGENTS.md. Rebased onto current main (486fbad + the MSG_ZEROCOPY fix in uring.rs, which is preserved).

PR 2/7 of the stacked series; the follow-up branches are based on this one and will be opened as this merges.

### Checklist

[] I have added unit tests to the code I am submitting — N/A, comments only
[] My unit tests cover both failure and success scenarios — N/A, comments only
[] If applicable, I have discussed my architecture — the series plan follows the policy laid out in e278542
