### PR TITLE
chore: change CI to use nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,5 @@
+[profile.default]
+slow-timeout = { period = "5s", terminate-after = 6 }
+
+[profile.ci]
+inherits = "default"

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -2,31 +2,31 @@
 set -euo pipefail
 
 target="${1:-}"
-test_threads="$(nproc)"
 
 sudo -E \
     PATH="${PATH}:/usr/share/rust/.cargo/bin" \
     TEST_TARGET="${target}" \
-    TEST_THREADS="${test_threads}" \
     bash -c '
         set -euo pipefail
 
         ulimit -Sl 512
         ulimit -Hl 512
 
-        echo "${TEST_THREADS} CPU(s) available"
         echo "PATH=${PATH}"
         rustup show
 
         args=(
-            test
+            nextest
+            run
             --locked
+            --profile
+            ci
         )
 
         if [[ -n "${TEST_TARGET}" ]]; then
             args+=(--target "${TEST_TARGET}")
         fi
 
-        exec cargo "${args[@]}" -- \
-            --test-threads="${TEST_THREADS}"
+        echo cargo "${args[@]}"
+        exec cargo "${args[@]}"
     '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,11 @@ jobs:
 
           cargo "${args[@]}"
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2.87.10
+        with:
+          tool: nextest@0.9.143
+
       - name: Run tests
         shell: bash
         env:


### PR DESCRIPTION
### What does this PR do?

Change CI to use nextest. I've pinned the version of the install action + nextest that gets installed to avoid supply chain attacks (both projects practice immutable releases so a release tag is a strict alias for a git tag and won't change).

### Motivation

https://github.com/glommio/glommio/actions/runs/34338267424/job/102561445543?pr=52 ended up hung running forever until it hit the default github action timeout of 360 minutes. This lets us set more aggressive timeouts because we know our tests don't need 60s before timing out. Additionally, any aborted test just fails that test instead of taking down the entire CI. Additionally, on my local machine cargo test -- --test-threads 32 still fails with "too many open files" whereas cargo nextest run has no such problem since each test gets its own isolated process.

As a bonus on my machine with 32 threads it's 5% faster (keeping in mind that 64 tests on my machine fail under cargo test at a parallelism of 32 so the true speedup may be even greater)

### Related issues

N/A

### Additional Notes

N/A
### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture